### PR TITLE
ci: bump checkout/setup-node to v6 (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
 

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: false
 

--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -14,7 +14,7 @@ jobs:
     if: startsWith(github.event.issue.title, '[example]')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Extract metadata and code from issue body
         id: extract
@@ -107,7 +107,7 @@ jobs:
           git switch -c "$BR"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
 


### PR DESCRIPTION
Silences the Node.js 20 deprecation warning across all three workflow files. Drop-in version bumps (v4/v5 → v6), matching the same fix in [gjsify/types#10](https://github.com/gjsify/types/pull/10), [gjsify/gjsify#238](https://github.com/gjsify/gjsify/pull/238), and [PixelRPG/map-editor#17](https://github.com/PixelRPG/map-editor/pull/17).