### PR TITLE
Link to package directories instead of README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ This project is a fork of the [original web-based easy6502 tutorial](https://git
 
 ## Packages
 
-- [app-gnome](./packages/app-gnome/README.md): Main GNOME desktop application with Adwaita styling
+- [app-gnome](./packages/app-gnome/): Main GNOME desktop application with Adwaita styling
 - [app-android](./packages/app-android/): Android application with NativeScript
-- [app-web](./packages/app-web/README.md): Web application version
-- [6502](./packages/6502/README.md): Core 6502 assembler, simulator, and disassembler
-- [common-ui](./packages/common-ui/README.md): Shared UI components and controllers
-- [learn](./packages/learn/README.md): Tutorial content and learning materials
-- [translations](./packages/translations/README.md): Localization files and build system
+- [app-web](./packages/app-web/): Web application version
+- [6502](./packages/6502/): Core 6502 assembler, simulator, and disassembler
+- [common-ui](./packages/common-ui/): Shared UI components and controllers
+- [learn](./packages/learn/): Tutorial content and learning materials
+- [translations](./packages/translations/): Localization files and build system
 
 ## Development
 


### PR DESCRIPTION
When linking to a README file, following the link shows only the README and not the project.
When linking to the package directory, **both** the project structure & the README file in that package directory are shown.