### PR TITLE
Gnome: register custom GTypes before templates

### DIFF
--- a/packages/app-gnome/src/main.ts
+++ b/packages/app-gnome/src/main.ts
@@ -2,6 +2,8 @@ import "./types/global.d.ts";
 import "@girs/gjs/dom";
 import "@girs/gjs";
 import { loop } from "./bootstrap.ts";
+// Register all custom GObject types before any window template is built (see file header).
+import "./register-types.ts";
 import { programInvocationName, exit } from "system";
 import { Application } from "./application.ts";
 

--- a/packages/app-gnome/src/register-types.ts
+++ b/packages/app-gnome/src/register-types.ts
@@ -1,0 +1,55 @@
+// GObject type registration barrel.
+//
+// Blueprint templates reference custom widgets by their `GTypeName` (e.g.
+// `$TutorialView`, `$QuickHelpView`, `$SourceView`). A custom type must already
+// be registered with the GObject type system *before* any template that embeds
+// it is instantiated, otherwise GTK aborts with
+// `Invalid object type '<Name>'`.
+//
+// Each widget module self-registers via its static `GObject.registerClass(...)`
+// block (and a trailing `GObject.type_ensure(...)`), but that code only runs if
+// the module is actually evaluated. Several consumer modules import their child
+// widgets with `import type { ... }`, which the bundler strips entirely — so the
+// child modules were never pulled into the bundle and never registered.
+//
+// Importing every self-registering module here for its side effects, before the
+// `Application` is constructed (see `main.ts`), guarantees all GTypes exist by
+// the time the first window template is built. When adding a new template
+// widget, add a side-effect import for it here.
+
+// Leaf widgets
+import "./widgets/source-view.ts";
+import "./widgets/main-button.ts";
+import "./widgets/menu-button.ts";
+import "./widgets/toolbar.ts";
+import "./widgets/accent-color-selector.ts";
+import "./widgets/primary-color-selector.ts";
+import "./widgets/theme-mode-selector.ts";
+import "./widgets/examples-list.ts";
+import "./widgets/example-list-item.ts";
+import "./widgets/share-dialog.ts";
+
+// Game console widgets
+import "./widgets/game-console/display.ts";
+import "./widgets/game-console/gamepad.ts";
+
+// Debugger widgets
+import "./widgets/debugger/debug-info.ts";
+import "./widgets/debugger/disassembled.ts";
+import "./widgets/debugger/hexdump.ts";
+import "./widgets/debugger/hex-monitor.ts";
+import "./widgets/debugger/message-console.ts";
+
+// MDX-driven widgets
+import "./mdx/mdx-view.ts";
+import "./mdx/quick-help-view.ts";
+import "./mdx/tutorial-view.ts";
+
+// Composite views and dialogs
+import "./views/main/game-console.ts";
+import "./views/main/debugger.ts";
+import "./views/main/editor.ts";
+import "./views/main/learn.ts";
+import "./views/main.window.ts";
+import "./views/help.window.ts";
+import "./views/preferences.dialog.ts";


### PR DESCRIPTION
## Problem

After #103 (dependency + oxc formatter bump), running `yarn && yarn build && yarn start` aborts while building the main window with:

```
Gtk-CRITICAL: Error building template class 'Learn' ...: Invalid object type 'TutorialView'
Gtk-CRITICAL: Error building template class 'Editor' ...: Invalid object type 'QuickHelpView'
... Custom constructor for class Learn returned NULL ...
TypeError: can't access property "events", this._sourceView is null
```

No usable window opens. Fixes #106.

## Root cause

Blueprint templates reference custom widgets by their `GTypeName` (e.g. `$TutorialView`, `$QuickHelpView`, `$SourceView`). A custom type must be registered with the GObject type system **before** any template embedding it is instantiated.

Each widget module self-registers via its static `GObject.registerClass(...)` block (plus a trailing `GObject.type_ensure(...)`), but that code only runs if the module is actually evaluated. Several consumers import their child widgets with `import type { ... }` (e.g. `main.window.ts` imports `Learn`/`Editor`/`GameConsole`/`Debugger` as types). The bundler strips type-only imports entirely, so those modules were never pulled into the bundle and never registered. The dependency/formatter bump in #103 changed the bundling so the latent bug started biting.

The rebuilt binary grew from ~531 KB to ~731 KB, confirming the widget modules were previously being tree-shaken out.

## Fix

Add `src/register-types.ts`, a side-effect import barrel for every self-registering widget/view/dialog module, loaded early from `main.ts` (before `Application` is constructed). This guarantees all GTypes exist before the first window template is built.

## Verification

- `yarn check:typescript` (gjsify tsc) passes.
- `yarn check:format` passes.
- App starts cleanly (default locale **and** Hebrew/RTL `LC_ALL=he_IL.UTF-8 LANGUAGE=he`): no `Invalid object type`, no `returned NULL`, no related JS errors; all views (learn/editor/debugger/game console) build and the simulator runs.