### PR TITLE
Gnome: use custom d-pad icons so RTL needs no swap

### DIFF
--- a/packages/app-gnome/data/eu.jumplink.Learn6502.data.gresource.xml
+++ b/packages/app-gnome/data/eu.jumplink.Learn6502.data.gresource.xml
@@ -8,6 +8,10 @@
     <file preprocess="xml-stripblanks">icons/scalable/actions/clipboard-symbolic.svg</file>
     <file preprocess="xml-stripblanks">icons/scalable/actions/code-symbolic.svg</file>
     <file preprocess="xml-stripblanks">icons/scalable/actions/dot-symbolic.svg</file>
+    <file preprocess="xml-stripblanks">icons/scalable/actions/dpad-down-symbolic.svg</file>
+    <file preprocess="xml-stripblanks">icons/scalable/actions/dpad-left-symbolic.svg</file>
+    <file preprocess="xml-stripblanks">icons/scalable/actions/dpad-right-symbolic.svg</file>
+    <file preprocess="xml-stripblanks">icons/scalable/actions/dpad-up-symbolic.svg</file>
     <file preprocess="xml-stripblanks">icons/scalable/actions/heart-filled-symbolic.svg</file>
     <file preprocess="xml-stripblanks">icons/scalable/actions/move-to-window-symbolic.svg</file>
     <file preprocess="xml-stripblanks">icons/scalable/actions/nintendo-controller-symbolic.svg</file>

--- a/packages/app-gnome/data/icons/scalable/actions/dpad-down-symbolic.svg
+++ b/packages/app-gnome/data/icons/scalable/actions/dpad-down-symbolic.svg
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" height="16px" viewBox="0 0 16 16" width="16px"><path d="m 3 5 l 5 7 l 5 -7 z" fill="#222222"/></svg>

--- a/packages/app-gnome/data/icons/scalable/actions/dpad-left-symbolic.svg
+++ b/packages/app-gnome/data/icons/scalable/actions/dpad-left-symbolic.svg
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" height="16px" viewBox="0 0 16 16" width="16px"><path d="m 11 3 l -7 5 l 7 5 z" fill="#222222"/></svg>

--- a/packages/app-gnome/data/icons/scalable/actions/dpad-right-symbolic.svg
+++ b/packages/app-gnome/data/icons/scalable/actions/dpad-right-symbolic.svg
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" height="16px" viewBox="0 0 16 16" width="16px"><path d="m 5 3 l 7 5 l -7 5 z" fill="#222222"/></svg>

--- a/packages/app-gnome/data/icons/scalable/actions/dpad-up-symbolic.svg
+++ b/packages/app-gnome/data/icons/scalable/actions/dpad-up-symbolic.svg
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" height="16px" viewBox="0 0 16 16" width="16px"><path d="m 3 11 l 5 -7 l 5 7 z" fill="#222222"/></svg>

--- a/packages/app-gnome/src/widgets/game-console/gamepad.blp
+++ b/packages/app-gnome/src/widgets/game-console/gamepad.blp
@@ -17,7 +17,7 @@ template $Gamepad: Adw.Bin {
 
       Button buttonLeft {
         name: "buttonLeft";
-        icon-name: "go-previous";
+        icon-name: "dpad-left-symbolic";
         margin-end: 0;
         valign: center;
         height-request: 50;
@@ -34,7 +34,7 @@ template $Gamepad: Adw.Bin {
 
         Button buttonUp {
           name: "buttonUp";
-          icon-name: "go-up";
+          icon-name: "dpad-up-symbolic";
           valign: center;
           halign: center;
           height-request: 50;
@@ -62,7 +62,7 @@ template $Gamepad: Adw.Bin {
 
         Button buttonDown {
           name: "buttonDown";
-          icon-name: "go-down";
+          icon-name: "dpad-down-symbolic";
           valign: center;
           halign: center;
           height-request: 50;
@@ -78,7 +78,7 @@ template $Gamepad: Adw.Bin {
 
       Button buttonRight {
         name: "buttonRight";
-        icon-name: "go-next";
+        icon-name: "dpad-right-symbolic";
         valign: center;
         halign: center;
         height-request: 50;

--- a/packages/app-gnome/src/widgets/game-console/gamepad.ts
+++ b/packages/app-gnome/src/widgets/game-console/gamepad.ts
@@ -31,14 +31,12 @@ export class Gamepad extends Adw.Bin implements GamepadWidget {
   constructor(params: Partial<Adw.Bin.ConstructorProps> = {}) {
     super(params);
 
-    // The d-pad is a spatial control, not text: keep its inner layout
-    // left-to-right in every locale. In RTL, GTK mirrors the d-pad box, which
-    // moves the buttons but not their physical rounded corners (so the cross
-    // breaks) and flips the go-previous/go-next arrows.
+    // The d-pad is a spatial control, not text: keep its inner layout LTR in
+    // every locale so the Left/Right buttons stay where their icons say they
+    // are. The icons themselves are custom (dpad-*-symbolic) and never get
+    // mirrored by the theme, so no icon swap is needed.
     if (this.get_direction() === Gtk.TextDirection.RTL) {
       this._buttonLeft.parent!.set_direction(Gtk.TextDirection.LTR);
-
-      [this._buttonLeft.iconName, this._buttonRight.iconName] = [this._buttonRight.iconName, this._buttonLeft.iconName];
     }
 
     this._buttonUp.connect("clicked", () => {


### PR DESCRIPTION
## Summary
- Ship four app-local `dpad-up/down/left/right-symbolic` SVGs (plain filled triangles) and reference them from `gamepad.blp` instead of the theme's `go-previous` / `go-next` / `go-up` / `go-down`.
- The theme arrows are direction-aware and get mirrored in RTL, which is why #107 needed both `set_direction(LTR)` on the inner d-pad box **and** a runtime icon swap. Custom icons aren't in the theme's mirroring lookup, so the swap is no longer needed.
- `set_direction(LTR)` stays, because the inner d-pad box is a spatial control and the buttons must keep their physical positions matching the icons.

## Why
Side-by-side RTL test on the merged #107 confirmed both pieces were needed _together_ on the current state — only `set_direction(LTR)` left the arrows visually inverted (left button showed a right-pointing chevron and vice versa). Replacing the icons removes the reason for the swap entirely; only the layout pin remains.

## Test plan
- [x] `yarn build` clean
- [x] `yarn check:format` clean
- [x] Launched with `LC_ALL=he_IL.utf8 LANGUAGE=he` — d-pad triangles correct (◀ on left, ▶ on right, ▲ top, ▼ bottom), cross-shape intact, A/B and FAB mirror as expected.
- [ ] Launch in default LTR locale — d-pad unchanged.