### PR TITLE
node 26 support

### DIFF
--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -11,7 +11,7 @@
     "./examples": "./examples.ts"
   },
   "scripts": {
-    "build": "node --experimental-specifier-resolution=node --experimental-strip-types --experimental-transform-types --no-warnings build.ts"
+    "build": "node --experimental-specifier-resolution=node --experimental-strip-types --no-warnings build.ts"
   },
   "devDependencies": {
     "@types/node": "^25.9.1",


### PR DESCRIPTION
The `--experimental-transform-types` flag does not work on node v26 (https://github.com/nodejs/typescript/issues/51#issuecomment-4421528927), and it seems to me it is not required anyway.

Tested with 24, 25, 26.