### PR TITLE
Gnome: force RTL base direction in MDX views

### DIFF
--- a/packages/app-gnome/src/mdx/mdx-view.ts
+++ b/packages/app-gnome/src/mdx/mdx-view.ts
@@ -1,7 +1,11 @@
 import GObject from "@girs/gobject-2.0";
 import Adw from "@girs/adw-1";
-import type { SourceView } from "../widgets/source-view.ts";
+import Gtk from "@girs/gtk-4.0";
+import { SourceView } from "../widgets/source-view.ts";
 import type { SourceViewCopyEvent } from "@learn6502/common-ui";
+
+/** RIGHT-TO-LEFT MARK (U+200F) — an invisible character with strong RTL directionality. */
+const RLM = "\u200F";
 
 /**
  * Base class for rendering MDX content in GTK
@@ -29,6 +33,9 @@ export class MdxView extends Adw.Bin {
     if (this.constructor === MdxView) {
       throw new Error("MdxView is a base class and should not be instantiated directly");
     }
+    if (this.get_direction() === Gtk.TextDirection.RTL) {
+      this.applyRtlBaseDirection(this);
+    }
   }
 
   protected setupSourceViews(sourceViewIds: string[]) {
@@ -47,6 +54,33 @@ export class MdxView extends Adw.Bin {
       return this[propertyName] as unknown as SourceView;
     }
     throw new Error(`SourceView with id ${id} not found`);
+  }
+
+  /**
+   * Force the RTL base direction on all text labels of the rendered MDX content.
+   *
+   * Pango derives each paragraph's base direction from its first strong
+   * directional character, so a translated paragraph that happens to start
+   * with an LTR word (e.g. a mnemonic like "LDA") would flip to left-to-right
+   * layout in RTL locales. Prepending an invisible RIGHT-TO-LEFT MARK gives
+   * every paragraph an RTL first strong character instead.
+   *
+   * @see https://github.com/JumpLink/Learn6502/issues/116
+   */
+  protected applyRtlBaseDirection(widget: Gtk.Widget): void {
+    for (let child = widget.get_first_child(); child !== null; child = child.get_next_sibling()) {
+      // Code blocks are intentionally kept in LTR layout
+      if (child instanceof SourceView) {
+        continue;
+      }
+      if (child instanceof Gtk.Label && child.label) {
+        child.label = child.label
+          .split("\n")
+          .map((line) => (line.startsWith(RLM) ? line : RLM + line))
+          .join("\n");
+      }
+      this.applyRtlBaseDirection(child);
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #116

## Problem

Pango derives each paragraph's base direction from its **first strong directional character**. When a translated tutorial paragraph starts with an LTR word (e.g. a mnemonic like `LDA`, or register/flag names like `SP`, `PC`, `BCC`), the whole paragraph flipped to left-to-right layout and left alignment — even in RTL locales like Hebrew.

## Fix

In `MdxView` (the base class of the tutorial and quick-help views): when the widget direction is RTL, walk the rendered widget tree and prepend an invisible RIGHT-TO-LEFT MARK (U+200F) to every line of every `GtkLabel`. This gives each paragraph an RTL first strong character, so Pango lays it out right-to-left; embedded LTR runs (mnemonics, hex values, inline code) are still rendered correctly by the bidi algorithm. `SourceView` code blocks are skipped and intentionally keep their LTR layout.

## Verification

GJS integration test loading the real generated `tutorial.ui` template with the real Hebrew translations and `Gtk.TextDirection.RTL` as default direction (as in a Hebrew locale):

| | without fix | with fix |
|---|---|---|
| Labels with Hebrew text | 144 | 144 |
| Hebrew labels rendered LTR (the bug) | **9** | **0** |
| Code blocks skipped (stay LTR) | 26 | 26 |

Also passing: `yarn format`, `yarn check:format`, `yarn build`, app-gnome TypeScript check.

## Notes

- The web app is unaffected (English only, no translations).
- The Android app likely has the same issue (Android `TextView` also uses first-strong detection); that would be a separate follow-up fix.