### PR TITLE
Gnome: bidi-isolate inline code in RTL MDX views

### DIFF
--- a/packages/app-gnome/src/mdx/mdx-view.ts
+++ b/packages/app-gnome/src/mdx/mdx-view.ts
@@ -7,6 +7,12 @@ import type { SourceViewCopyEvent } from "@learn6502/common-ui";
 /** RIGHT-TO-LEFT MARK (U+200F) — an invisible character with strong RTL directionality. */
 const RLM = "\u200F";
 
+/** FIRST STRONG ISOLATE (U+2068) — starts a bidi-isolated run whose direction is detected from its content. */
+const FSI = "\u2068";
+
+/** POP DIRECTIONAL ISOLATE (U+2069) — ends a bidi-isolated run. */
+const PDI = "\u2069";
+
 /**
  * Base class for rendering MDX content in GTK
  * Provides common functionality for handling source views and other MDX elements
@@ -65,6 +71,9 @@ export class MdxView extends Adw.Bin {
    * layout in RTL locales. Prepending an invisible RIGHT-TO-LEFT MARK gives
    * every paragraph an RTL first strong character instead.
    *
+   * Inline code spans are additionally bidi-isolated so that neutral
+   * punctuation next to them resolves against the RTL paragraph direction.
+   *
    * @see https://github.com/JumpLink/Learn6502/issues/116
    */
   protected applyRtlBaseDirection(widget: Gtk.Widget): void {
@@ -77,10 +86,29 @@ export class MdxView extends Adw.Bin {
         child.label = child.label
           .split("\n")
           .map((line) => (line.startsWith(RLM) ? line : RLM + line))
+          .map((line) => this.isolateInlineCode(line))
           .join("\n");
       }
       this.applyRtlBaseDirection(child);
     }
+  }
+
+  /**
+   * Wrap the content of inline code spans in bidi isolates.
+   *
+   * Without isolation, neutral characters (quotes, dots, colons) between an
+   * LTR code span and an adjacent LTR word join them into one left-to-right
+   * run, so the punctuation jumps to its LTR position inside RTL text — e.g.
+   * in `<tt>BNE</tt>: "Branch on not equal"` the colon and the opening quote
+   * stuck to the LTR run while the closing quote resolved right-to-left.
+   * Isolating the span makes all surrounding punctuation resolve uniformly
+   * against the RTL paragraph direction; the bidi algorithm still renders the
+   * isolated code itself left-to-right.
+   *
+   * @see https://github.com/JumpLink/Learn6502/issues/117
+   */
+  private isolateInlineCode(markup: string): string {
+    return markup.replace(/<tt>(?!\u2068)/g, `<tt>${FSI}`).replace(/(?<!\u2069)<\/tt>/g, `${PDI}</tt>`);
   }
 }
 


### PR DESCRIPTION
Fixes #117

## Problem

In RTL locales, neutral characters (quotes, dots, colons) next to LTR runs could resolve to the wrong side. The root cause for the asymmetric case reported in #117: when punctuation sits **between two LTR runs** — typically an inline-code mnemonic and a following English word — the Unicode bidi algorithm joins everything into one left-to-right run.

Real example from the Hebrew tutorial (`<tt>BNE</tt>: "Branch on not equal"` inside a Hebrew sentence): the colon and the *opening* quote stuck to the LTR run while the *closing* quote correctly resolved right-to-left — exactly the "quote before but not after LTR letters" asymmetry described in the issue.

Note: the simpler cases from the issue (punctuation between an LTR run and Hebrew text, or at line end) were already fixed by the RTL paragraph direction from #121; this PR fixes the remaining run-joining case.

## Fix

In `MdxView.applyRtlBaseDirection`, additionally wrap the content of `<tt>` spans in FIRST STRONG ISOLATE (U+2066–U+2069 family: FSI U+2068 / PDI U+2069) characters. Isolated runs are treated as neutral by the surrounding text, so all adjacent punctuation now resolves uniformly against the RTL paragraph direction, while the bidi algorithm still renders the isolated code itself left-to-right. FSI (first-strong) is used instead of LRI so the span direction always derives from its content. The transform is idempotent.

## Verification

GJS integration test loading the real generated `tutorial.ui` with the real Hebrew translations and `Gtk.TextDirection.RTL` (mirroring the #121 methodology):

| | without fix | with fix |
|---|---|---|
| Labels with Hebrew text | 144 | 144 |
| Hebrew labels with `<tt>` spans | 84 | 84 |
| Spans bidi-isolated | 0 | 84 |
| Labels with broken Pango markup | 0 | 0 |
| Hebrew labels rendered LTR (#116 regression check) | 0 | 0 |
| BNE paragraph: colon RTL-positioned | ❌ | ✅ |
| BNE paragraph: quotes hug the quoted phrase symmetrically | ❌ | ✅ |

Glyph positions verified via `PangoLayout.index_to_pos` on the rendered labels.

Also passing: `yarn format`, `yarn check:format`, `yarn build`, app-gnome type check (blueprint validation included).

## Notes

- Code blocks (`SourceView`) keep their intentional LTR layout, unchanged.
- The Android app renders the same MDX content with `TextView`/HTML and likely needs an equivalent fix — separate follow-up, same as noted in #121.