### PR TITLE
Gnome: exempt code widgets from RTL mirroring

### DIFF
--- a/packages/app-gnome/src/widgets/source-view.ts
+++ b/packages/app-gnome/src/widgets/source-view.ts
@@ -541,10 +541,15 @@ export class SourceView extends Adw.Bin implements SourceViewWidget {
       ...rest
     } = params;
     super(rest);
-    // Source code is inherently LTR content, so the whole widget is exempt
-    // from RTL mirroring — like in any code editor, the gutter, scrollbar
-    // and the floating copy button keep their LTR positions.
+    // Source code is inherently LTR content, so the widget is exempt from
+    // RTL mirroring — like in any code editor, the gutter, scrollbar and
+    // the floating copy button keep their LTR positions. GTK does not
+    // propagate the direction to existing children, so every widget that
+    // resolves its own alignment or margins must be pinned individually.
     this.set_direction(Gtk.TextDirection.LTR);
+    this._scrolledWindow.set_direction(Gtk.TextDirection.LTR);
+    this._sourceView.set_direction(Gtk.TextDirection.LTR);
+    this._copyButton.set_direction(Gtk.TextDirection.LTR);
     this.setupScrolledWindow();
 
     // Setup action group and actions

--- a/packages/app-gnome/src/widgets/source-view.ts
+++ b/packages/app-gnome/src/widgets/source-view.ts
@@ -541,6 +541,10 @@ export class SourceView extends Adw.Bin implements SourceViewWidget {
       ...rest
     } = params;
     super(rest);
+    // Source code is inherently LTR content, so the whole widget is exempt
+    // from RTL mirroring — like in any code editor, the gutter, scrollbar
+    // and the floating copy button keep their LTR positions.
+    this.set_direction(Gtk.TextDirection.LTR);
     this.setupScrolledWindow();
 
     // Setup action group and actions

--- a/packages/app-gnome/src/widgets/toolbar.ts
+++ b/packages/app-gnome/src/widgets/toolbar.ts
@@ -1,5 +1,6 @@
 import GObject from "@girs/gobject-2.0";
 import Adw from "@girs/adw-1";
+import Gtk from "@girs/gtk-4.0";
 
 import Template from "./toolbar.blp";
 
@@ -17,6 +18,11 @@ export class Toolbar extends Adw.Bin {
 
   constructor(params: Partial<Adw.Bin.ConstructorProps> = {}) {
     super(params);
+    // The toolbar floats over source code, which is inherently LTR content
+    // (it always starts at the left edge). Exempt it from RTL mirroring so
+    // "halign: end" keeps anchoring it over the mostly empty right side
+    // instead of covering the code.
+    this.set_direction(Gtk.TextDirection.LTR);
   }
 }
 


### PR DESCRIPTION
Follow-up to #121/#125, found while manually testing the RTL fixes under a real Hebrew locale (`he_IL.UTF-8`).

## Problem

In RTL locales the editor's floating toolbar (`halign: end` → mirrored to the *left*) ended up covering the source code, which always starts at the left edge. The same pattern affects the floating copy button of tutorial code blocks.

## Fix

Source code is inherently LTR content. Per the GNOME HIG mirroring exception for directionally-fixed content (the same rule that keeps media playback controls LTR in RTL apps), the code widgets are pinned to `Gtk.TextDirection.LTR`:

- **Toolbar** — stays anchored over the mostly empty right side of the editor instead of covering the code.
- **SourceView** — the whole widget (gutter, scrollbar, floating copy button) keeps standard code-editor LTR positions, matching how VS Code, JetBrains and GNOME Builder behave in RTL environments.

The text content itself was already rendered LTR (first-strong detection); this only fixes the chrome anchored to it.

## Verification

- Manually tested under `LC_ALL=he_IL.UTF-8`: toolbar no longer overlaps the code, copy button stays at the top right of code blocks; LTR locales unaffected.
- `yarn format`, `yarn check:format`, app-gnome type check pass.