### PR TITLE
Gnome: highlight cursor line only while editing

### DIFF
--- a/packages/app-gnome/src/widgets/source-view.ts
+++ b/packages/app-gnome/src/widgets/source-view.ts
@@ -262,6 +262,7 @@ export class SourceView extends Adw.Bin implements SourceViewWidget {
    */
   public set editable(value: boolean) {
     this._sourceView.set_editable(value);
+    this.updateCurrentLineHighlight();
   }
 
   /**
@@ -315,7 +316,7 @@ export class SourceView extends Adw.Bin implements SourceViewWidget {
         this.copyClipboardSignalId = undefined;
       }
     }
-    this._sourceView.highlight_current_line = true;
+    this.updateCurrentLineHighlight();
   }
 
   /**
@@ -801,6 +802,14 @@ export class SourceView extends Adw.Bin implements SourceViewWidget {
   }
 
   /**
+   * Highlight the cursor line only while editing: in read-only code blocks
+   * the idle cursor (sitting at the last line) would look like a selection.
+   */
+  private updateCurrentLineHighlight() {
+    this._sourceView.highlight_current_line = this._sourceView.editable;
+  }
+
+  /**
    * Update the style of the source view.
    * Used internally to update the style of the source view when the theme changes.
    */
@@ -812,7 +821,7 @@ export class SourceView extends Adw.Bin implements SourceViewWidget {
       scheme = this.schemeManager.get_scheme(isDark ? "Adwaita-dark" : "Adwaita");
     }
     if (scheme) this.buffer.set_style_scheme(scheme);
-    this._sourceView.set_highlight_current_line(true);
+    this.updateCurrentLineHighlight();
   }
 
   /**

--- a/packages/learn/tsx/components/gtk/gtk-code.compontent.tsx
+++ b/packages/learn/tsx/components/gtk/gtk-code.compontent.tsx
@@ -160,7 +160,9 @@ export class GtkCode extends GtkWidget<GtkCodeProps> {
    */
   protected parseAttributes(props: GtkCodeProps): Partial<GtkCodeProps> {
     let language = props.language || "";
-    let readonly = props.readonly || false;
+    // MDX code blocks are documentation, so they always render read-only;
+    // the only editable SourceView is the editor itself
+    let readonly = props.readonly ?? true;
     let copyable = props.copyable || false;
     let unselectable = props.unselectable || false;
     let noLineNumbers = props.noLineNumbers || false;


### PR DESCRIPTION
Fixes #130

## Problem

The last line of every tutorial code block was highlighted like a selection — the idle text cursor sits at the buffer end and `highlight_current_line` was enabled unconditionally (in both the `language` setter and `updateStyle()`). On wide layouts the highlight only became visible after hover triggered a redraw, matching the reported behavior.

## Fix (two parts)

1. **Gnome:** the cursor-line highlight is now tied to the editable state via a single helper, called from the `editable` setter, the `language` setter and `updateStyle()` — the editor keeps its highlight, read-only views never show one.
2. **Learn:** only blocks explicitly marked `:readonly` in the MDX were rendered read-only; the `:copyable` example blocks were silently **editable** (you could type into them), so part 1 alone did not cover them. MDX code blocks are documentation — they now always render read-only; the only editable SourceView is the editor itself.

Note: the Android renderer (`ns-code`) has the same editable-by-default behavior; whether it needs the same treatment is part of the broader Android RTL/tutorial follow-up.

## Verification

Manually tested (Hebrew + German): no tutorial block shows a highlighted last line (also not after hover), tutorial blocks no longer accept text input, the editor keeps its cursor-line highlight, and copy-to-editor still works.