### PR TITLE
Gnome: anchor run toolbar to the editor column

### DIFF
--- a/packages/app-gnome/src/views/main.window.blp
+++ b/packages/app-gnome/src/views/main.window.blp
@@ -173,10 +173,25 @@ template $MainWindow: Adw.ApplicationWindow {
                     hexpand: true;
                     vexpand: true;
 
-                    // Center column (Editor)
-                    Box centerColumn {
+                    // Center column (Editor) with the run toolbar anchored to
+                    // its edge, so it tracks the editor across all breakpoints
+                    // and text directions instead of relying on a fixed margin
+                    Overlay centerOverlay {
                       hexpand: true;
                       vexpand: true;
+
+                      child: Box centerColumn {
+                        hexpand: true;
+                        vexpand: true;
+                      };
+
+                      [overlay]
+                      $Toolbar runToolbar {
+                        halign: end;
+                        valign: start;
+                        margin-end: 12;
+                        margin-top: 12;
+                      }
                     }
 
                     Separator {}
@@ -229,13 +244,6 @@ template $MainWindow: Adw.ApplicationWindow {
         margin-bottom: 0;
       }
 
-      [overlay]
-      $Toolbar runToolbar {
-        halign: end;
-        valign: start;
-        margin-end: 360;
-        margin-top: 46;
-      }
     };
 
     [bottom]


### PR DESCRIPTION
Fixes #131

## Problem

The floating run toolbar was an overlay child of the window-level `mainOverlay`, positioned with `halign: end; margin-end: 360` — the 360px were meant to clear the panel next to the editor. But the adjacent panel is an `Adw.OverlaySplitView` sidebar with breakpoint-dependent width (max 344px medium, up to 800px ultra-wide) and a toggle:

- **Medium layout:** sidebar closed, but the 360px were still reserved → toolbar floated awkwardly mid-window.
- **Ultra-wide layout:** sidebar wider than 360px → toolbar floated on top of the tutorial text.

## Fix

The toolbar is now an overlay anchored to the editor column itself (`Overlay centerOverlay` around `centerColumn` in the three-column layout), with plain 12px margins. It sticks to the editor's edge in every breakpoint and both text directions — no magic margins left.

Input is unaffected: `Gtk.Overlay` only intercepts events within the overlay child's own bounds (same mechanism as the per-code-block copy button), the editor receives clicks and keyboard input everywhere else.

The toolbar keeps its LTR pin from #126, so `halign: end` means the editor's right edge in RTL too — matching the LTR code content.

The `runToolbar` id and the breakpoint visibility setters are unchanged; the mobile layout still uses the main button instead.

## Verification

Manually tested in German and Hebrew (RTL) at all four breakpoints (mobile / medium with sidebar open+closed / wide / ultra-wide ≥1600px): toolbar stays at the editor's top right edge; no overlap with the tutorial panel. `yarn format`, `yarn check:format`, app-gnome build (blueprint validation) pass.