### PR TITLE
Gnome: equalize d-pad cell widths

### DIFF
--- a/packages/app-gnome/src/widgets/game-console/gamepad.css
+++ b/packages/app-gnome/src/widgets/game-console/gamepad.css
@@ -1,0 +1,10 @@
+#gamepad #buttonCenter {
+  /* The center filler is an empty button, so it keeps the default button
+     padding (10px per side) instead of the 5px the surrounding icon buttons
+     get from .image-button. Combined with osd's 32px min-width that pushes
+     its minimum width to 52px, overruling the 50px width-request shared by
+     all d-pad cells and offsetting the up/down buttons by 1px per side.
+     Match the icon buttons' padding so every cell stays exactly 50px. */
+  padding-left: 5px;
+  padding-right: 5px;
+}

--- a/packages/app-gnome/src/widgets/index.css
+++ b/packages/app-gnome/src/widgets/index.css
@@ -1,8 +1,9 @@
-@import './theme-mode-selector.css';
-@import './primary-color-selector.css';
-@import './accent-color-selector.css';
-@import './examples-list.css';
-@import './example-list-item.css';
-@import './main-button.css';
-@import './source-view.css';
-@import './toolbar.css';
+@import "./theme-mode-selector.css";
+@import "./primary-color-selector.css";
+@import "./accent-color-selector.css";
+@import "./examples-list.css";
+@import "./example-list-item.css";
+@import "./main-button.css";
+@import "./source-view.css";
+@import "./toolbar.css";
+@import "./game-console/gamepad.css";


### PR DESCRIPTION
## Summary

The up/down d-pad buttons were 2px narrower than the center box (1px offset per side), see #136.

**Cause:** All d-pad buttons share `width-request: 50`. The icon buttons get 5px horizontal padding from libadwaita's `.image-button` rule, so their CSS minimum (32px osd `min-width` + 10px) stays below the width-request. The empty center filler is not an image button and keeps the default 10px-per-side padding, pushing its minimum width to 52px — overruling the width-request. With `halign: center`, the 50px up/down buttons floated centered inside the 52px column.

**Fix:** Give the center filler the same horizontal padding as the icon buttons via a new `gamepad.css`, so every cell is exactly 50px.

## Verification

Ran the app and pixel-analyzed a screenshot of the d-pad: up, center, and down cells now all span the same 50px (previously the center was 52px wide); all seams are flush, including the left/right button rows.

| Before | After |
|---|---|
| Up button left edge offset 1px from center box | All three vertical cells share identical edges |

Fixes #136