### PR TITLE
Learn: pin generator to explicit node globals

### DIFF
--- a/packages/learn/package.json
+++ b/packages/learn/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "build:mdx": "gjsify build tsx/index.tsx --app gjs --outfile dist/index.js",
+    "build:mdx": "gjsify build tsx/index.tsx --app gjs --globals node --outfile dist/index.js",
     "build:js": "gjsify run dist/index.js",
     "build": "gjsify run build:mdx && gjsify run build:js && gjsify run build:copy",
     "build:copy": "cp -r dist/tutorial.ns.xml ../app-android/app/mdx/tutorial.xml && cp -r dist/quick-help.ns.xml ../app-android/app/mdx/quick-help.xml",
@@ -14,21 +14,6 @@
   "author": "Nick Morgan, Pascal Garber",
   "license": "CC-BY-4.0",
   "gjsify": {
-    "globals": "auto",
-    "excludeGlobals": [
-      "document",
-      "Image",
-      "HTMLCanvasElement",
-      "HTMLImageElement",
-      "HTMLElement",
-      "MutationObserver",
-      "ResizeObserver",
-      "IntersectionObserver",
-      "FontFace",
-      "matchMedia",
-      "location",
-      "navigator"
-    ],
     "loaders": {
       ".asm": "text"
     },


### PR DESCRIPTION
## Replace `--globals auto` with an explicit node allowlist for the MDX generator

Follow-up to #148. The generator's runtime needs are fully known — Node globals for `fs.writeFile`, nothing else (nano-jsx provides its own SSR `document`). So an **explicit allowlist** is the right tool here, not auto-detect.

### Why explicit beats auto for this generator
- nano-jsx is a **universal** library: it statically references DOM globals (`document`, `HTMLElement`, `IntersectionObserver`, `MutationObserver`) in browser/lifecycle code (`didMount`, `customElements`) that **never runs under `renderSSR`**. `--globals auto` *correctly* detects those static refs and injects `@gjsify/dom-elements`, which transitively pulls `gi://Gdk`/`GdkPixbuf`/`Pango`/`PangoCairo` → crashes the GTK-less *Type check (GJS 1.86)* job. The detection isn't wrong; static analysis just can't know those paths are SSR-dead.
- An allowlist **can't regress** into DOM/Gdk no matter what nano-jsx references later, needs **no denylist upkeep**, and produces the **smaller bundle**: **312 KB** vs the auto+exclude 390 KB (auto also injected web-streams registers the generator never uses at runtime).

This supersedes #148's `globals: auto` + `excludeGlobals: [DOM group]`. (Side note: the `gjsify` config block can't set `globals` — the CLI `--globals` default `auto` always overrides a config value — so it must be passed on the CLI. A gjsify fix for that config-precedence gap is tracked separately.)

### Validation
- `gjsify run build:mdx` → GI refs **Gio/GioUnix/GLib only** (no Gdk), 312 KB.
- Generator runs under `gjs` (exit 0); all six `.ui`/`.ns.xml`/`.html` outputs **byte-identical** to the previous build.