### PR TITLE
build: support npm/yarn/pnpm + Changesets publishing

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -1,0 +1,9 @@
+# Changesets
+
+This folder is managed by [Changesets](https://github.com/changesets/changesets) — it drives the version bumps, changelogs and npm publishing for this monorepo.
+
+- **Add a changeset** for your change: `npm run changeset` (or `yarn`/`pnpm`/`gjsify run changeset`). Pick the affected packages and the bump type, write a one-line summary. Commit the generated `.changeset/*.md` with your PR.
+- All `@learn6502/*` packages are **version-locked** (`fixed` group) — they bump together, keeping the internal `^x.y.z` ranges consistent. Changesets rewrites those internal ranges automatically on `version`, so you never hand-sync them.
+- Only **`@learn6502/6502`** is published to npm; the other packages are `private` (they still get versioned + changelogged, just not published).
+
+Release flow (maintainer): `npm run changeset:version` (applies pending changesets → bumps versions + internal ranges + writes CHANGELOGs), commit, then `npm run changeset:publish` (builds + `changeset publish`).

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
+  "changelog": "@changesets/cli/changelog",
+  "commit": false,
+  "fixed": [["@learn6502/*"]],
+  "linked": [],
+  "access": "public",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": []
+}

--- a/.github/workflows/package-managers.yml
+++ b/.github/workflows/package-managers.yml
@@ -1,0 +1,75 @@
+# Verifies the repo installs + resolves its workspaces with every supported
+# package manager — npm, yarn, pnpm and gjsify. Deliberately NOT run per-PR
+# (the normal CI on every PR uses gjsify): this is manual (`workflow_dispatch`)
+# plus a weekly safety-net cron, so a regression in the multi-PM contract
+# (e.g. someone reintroduces the `workspace:` protocol, which npm/yarn-v1 can't
+# resolve) is still caught without taxing every PR.
+name: Package Managers
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Weekly, Monday 05:00 UTC — light insurance, not per-PR.
+    - cron: "0 5 * * 1"
+
+jobs:
+  install-and-resolve:
+    name: ${{ matrix.pm }}
+    runs-on: ubuntu-latest
+    # Fedora ships gjs (SpiderMonkey) — needed by `gjsify tsc`, which the
+    # build/check scripts spawn. Mirrors the CI `type-check` job's container.
+    container:
+      image: fedora:43
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # npm/yarn-v1/pnpm only work because internal deps use plain `^x.y.z`
+          # ranges (NOT the `workspace:` protocol). pnpm additionally needs the
+          # committed pnpm-workspace.yaml (+ nodeLinker: hoisted) in the repo.
+          - pm: npm
+            setup: ""
+            install: "npm install"
+          - pm: yarn
+            setup: "npm install -g yarn"
+            install: "yarn install"
+          - pm: pnpm
+            setup: "npm install -g pnpm"
+            install: "pnpm install"
+          - pm: gjsify
+            setup: "npm install -g @gjsify/cli@^0.10.0"
+            install: "gjsify install"
+
+    steps:
+      - name: Install system prerequisites (incl. gjs)
+        run: dnf install -y git tar xz findutils gjs
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Setup + install with ${{ matrix.pm }}
+        # Matrix values are trusted workflow constants; passed via env (not
+        # inlined into the script) per the GitHub-Actions injection guidance.
+        env:
+          SETUP: ${{ matrix.setup }}
+          INSTALL: ${{ matrix.install }}
+        run: |
+          set -eux
+          if [ -n "$SETUP" ]; then sh -c "$SETUP"; fi
+          sh -c "$INSTALL"
+
+      - name: Verify workspace resolution (build 6502 → type-check common-ui)
+        # common-ui imports @learn6502/6502; this only type-checks if the PM
+        # symlinked the workspace + resolved the internal `^x.y.z` range to the
+        # local package. The lightest decisive cross-workspace check (gjs only,
+        # no GTK build deps). The full app-gnome build is covered by flatpak.yml.
+        run: |
+          set -eux
+          export PATH="$PWD/node_modules/.bin:$PATH"
+          gjsify workspace @learn6502/6502 build
+          gjsify workspace @learn6502/common-ui check

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,13 @@
+# pnpm-specific settings. npm/yarn/gjsify ignore these keys (npm may print a
+# cosmetic "unknown config" for node-linker — install still works).
+#
+# link-workspace-packages: the internal deps use plain `^x.y.z` ranges (not the
+# `workspace:` protocol). pnpm 10 defaults this to false, so without it pnpm
+# fetches @learn6502/* from the registry (404) instead of linking the local
+# workspace. true makes pnpm resolve a workspace-named dep to the local package.
+link-workspace-packages=true
+# node-linker: flat node_modules (like npm/yarn/gjsify). pnpm's default strict
+# symlinked layout hides the gjsify bundler's node-builtin polyfills
+# (@gjsify/node-globals etc.) → `--globals auto` fails the build with
+# "Unsupported URI scheme for importing: node".
+node-linker=hoisted

--- a/README.md
+++ b/README.md
@@ -41,18 +41,28 @@ This project is a fork of the [original web-based easy6502 tutorial](https://git
 
 ### Local Development
 
-To get started with local development:
+The repository works with **gjsify** (recommended), **npm**, **yarn** or **pnpm** — use whichever you're comfortable with.
 
 ```bash
-# Install dependencies
+# Recommended — gjsify (the canonical toolchain)
 gjsify install
-
-# Build all packages
 gjsify run build
-
-# Start the GNOME application
 gjsify run start:gnome
 ```
+
+Prefer npm / yarn / pnpm? They all work too — each installs the workspaces and resolves the internal dependencies; the build itself still runs through gjsify (it's a dev dependency, so its bin is available after any install):
+
+```bash
+npm install        # or:  yarn install   |   pnpm install
+npm run build && npm run start:gnome      # or the yarn / pnpm equivalent
+```
+
+Notes:
+
+- **gjsify is the canonical path** — the committed `gjsify-lock.json` and the offline Flatpak build use it. npm/yarn/pnpm generate their own lockfiles (gitignored); they're fine for local dev, please don't commit them.
+- **pnpm** relies on the committed `pnpm-workspace.yaml` (pnpm doesn't read the `workspaces` field) plus `.npmrc` — `link-workspace-packages=true` (so plain `^` ranges link the local workspaces) and `node-linker=hoisted` (flat layout the gjsify bundler needs).
+- The internal packages use plain `^x.y.z` ranges (not the `workspace:` protocol), which is why every manager — including npm and classic yarn — can resolve them.
+- A manual **Package Managers** CI workflow verifies all four managers install + resolve the workspaces; trigger it from the Actions tab if you touch the dependency wiring.
 
 ### Flatpak Build
 
@@ -63,6 +73,10 @@ To build the packages, run `gjsify run build` in the root of the repository.
 ### Running
 
 To run the packages, run `gjsify run start:gnome` for the GNOME app or `gjsify run start:web` for the web app.
+
+### Releasing
+
+Versioning, changelogs and npm publishing are managed with [Changesets](https://github.com/changesets/changesets) (see [`.changeset/README.md`](.changeset/README.md)). Add a changeset with your change (`gjsify run changeset`, or `npm`/`yarn`/`pnpm run changeset`). All `@learn6502/*` packages are version-locked and bump together; only `@learn6502/6502` is published to npm (the rest are private). Maintainer release: `… run changeset:version` then `… run changeset:publish`.
 
 ## Contributing
 

--- a/gjsify-lock.json
+++ b/gjsify-lock.json
@@ -1,6 +1,7 @@
 {
   "lockfileVersion": 2,
   "requested": [
+    "@changesets/cli@^2.27.0",
     "@gjsify/cli@^0.10.0",
     "@gjsify/lightningcss-native@^0.10.0",
     "@gjsify/rolldown-native@^0.10.0",
@@ -458,11 +459,6 @@
         "mimic-function": "^5.0.0"
       }
     },
-    "node_modules/@angular-devkit/build-angular/node_modules/ora/node_modules/cli-cursor/node_modules/restore-cursor/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
-    },
     "node_modules/@angular-devkit/build-angular/node_modules/ora/node_modules/cli-spinners": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
@@ -539,14 +535,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="
-    },
-    "node_modules/@angular-devkit/build-angular/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/tinyglobby": {
       "version": "0.2.15",
@@ -896,14 +884,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="
-    },
-    "node_modules/@angular/build/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
     },
     "node_modules/@angular/build/node_modules/tinyglobby": {
       "version": "0.2.15",
@@ -1965,6 +1945,230 @@
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
         "@babel/helper-validator-identifier": "^7.29.7"
+      }
+    },
+    "node_modules/@changesets/apply-release-plan": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.1.1.tgz",
+      "integrity": "sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==",
+      "dependencies": {
+        "semver": "^7.5.3",
+        "outdent": "^0.5.0",
+        "fs-extra": "^7.0.1",
+        "prettier": "^2.7.1",
+        "resolve-from": "^5.0.0",
+        "detect-indent": "^6.0.0",
+        "@changesets/git": "^3.0.4",
+        "lodash.startcase": "^4.4.0",
+        "@changesets/types": "^6.1.0",
+        "@changesets/config": "^3.1.4",
+        "@manypkg/get-packages": "^1.1.3",
+        "@changesets/should-skip-package": "^0.1.2",
+        "@changesets/get-version-range-type": "^0.4.0"
+      }
+    },
+    "node_modules/@changesets/apply-release-plan/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      }
+    },
+    "node_modules/@changesets/assemble-release-plan": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.10.tgz",
+      "integrity": "sha512-rSDcqdJ9KbVyjpBIuCidhvZNIiVt1XaIYp73ycVQRIA5n/j6wQaEk0ChRLMUQ1vkxZe51PTQ9OIhbg6HQMW45A==",
+      "dependencies": {
+        "semver": "^7.5.3",
+        "@changesets/types": "^6.1.0",
+        "@changesets/errors": "^0.2.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "@changesets/should-skip-package": "^0.1.2",
+        "@changesets/get-dependents-graph": "^2.1.4"
+      }
+    },
+    "node_modules/@changesets/changelog-git": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.2.1.tgz",
+      "integrity": "sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==",
+      "dependencies": {
+        "@changesets/types": "^6.1.0"
+      }
+    },
+    "node_modules/@changesets/cli": {
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.31.0.tgz",
+      "integrity": "sha512-AhI4enNTgHu2IZr6K4WZyf0EPch4XVMn1yOMFmCD9gsfBGqMYaHXls5HyDv6/CL5axVQABz68eG30eCtbr2wFg==",
+      "dependencies": {
+        "mri": "^1.2.0",
+        "semver": "^7.5.3",
+        "enquirer": "^2.4.1",
+        "fs-extra": "^7.0.1",
+        "term-size": "^2.1.0",
+        "picocolors": "^1.1.0",
+        "ansi-colors": "^4.1.3",
+        "spawndamnit": "^3.0.1",
+        "resolve-from": "^5.0.0",
+        "@changesets/git": "^3.0.4",
+        "@changesets/pre": "^2.0.2",
+        "@changesets/read": "^0.6.7",
+        "@changesets/types": "^6.1.0",
+        "@changesets/write": "^0.4.0",
+        "@changesets/config": "^3.1.4",
+        "@changesets/errors": "^0.2.0",
+        "@changesets/logger": "^0.1.1",
+        "@manypkg/get-packages": "^1.1.3",
+        "package-manager-detector": "^0.2.0",
+        "@changesets/changelog-git": "^0.2.1",
+        "@inquirer/external-editor": "^1.0.2",
+        "@changesets/get-release-plan": "^4.0.16",
+        "@changesets/apply-release-plan": "^7.1.1",
+        "@changesets/should-skip-package": "^0.1.2",
+        "@changesets/get-dependents-graph": "^2.1.4",
+        "@changesets/assemble-release-plan": "^6.0.10"
+      },
+      "bin": {
+        "changeset": "bin.js"
+      }
+    },
+    "node_modules/@changesets/config": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.1.4.tgz",
+      "integrity": "sha512-pf0bvD/v6WI2cRlZ6hzpjtZdSlXDXMAJ+Iz7xfFzV4ZxJ8OGGAON+1qYc99ZPrijnt4xp3VGG7eNvAOGS24V1Q==",
+      "dependencies": {
+        "fs-extra": "^7.0.1",
+        "micromatch": "^4.0.8",
+        "@changesets/types": "^6.1.0",
+        "@changesets/errors": "^0.2.0",
+        "@changesets/logger": "^0.1.1",
+        "@manypkg/get-packages": "^1.1.3",
+        "@changesets/should-skip-package": "^0.1.2",
+        "@changesets/get-dependents-graph": "^2.1.4"
+      }
+    },
+    "node_modules/@changesets/errors": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@changesets/errors/-/errors-0.2.0.tgz",
+      "integrity": "sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==",
+      "dependencies": {
+        "extendable-error": "^0.1.5"
+      }
+    },
+    "node_modules/@changesets/get-dependents-graph": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-2.1.4.tgz",
+      "integrity": "sha512-ZsS00x6WvmHq3sQv8oCMwL0f/z3wbXCVuSVTJwCnnmbC/iBdNJGFx1EcbMG4PC6sXRyH69liM4A2WKXzn/kRPg==",
+      "dependencies": {
+        "semver": "^7.5.3",
+        "picocolors": "^1.1.0",
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3"
+      }
+    },
+    "node_modules/@changesets/get-release-plan": {
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.16.tgz",
+      "integrity": "sha512-2K5Om6CrMPm45rtvckfzWo7e9jOVCKLCnXia5eUPaURH7/LWzri7pK1TycdzAuAtehLkW7VPbWLCSExTHmiI6g==",
+      "dependencies": {
+        "@changesets/pre": "^2.0.2",
+        "@changesets/read": "^0.6.7",
+        "@changesets/types": "^6.1.0",
+        "@changesets/config": "^3.1.4",
+        "@manypkg/get-packages": "^1.1.3",
+        "@changesets/assemble-release-plan": "^6.0.10"
+      }
+    },
+    "node_modules/@changesets/get-version-range-type": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@changesets/get-version-range-type/-/get-version-range-type-0.4.0.tgz",
+      "integrity": "sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ=="
+    },
+    "node_modules/@changesets/git": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@changesets/git/-/git-3.0.4.tgz",
+      "integrity": "sha512-BXANzRFkX+XcC1q/d27NKvlJ1yf7PSAgi8JG6dt8EfbHFHi4neau7mufcSca5zRhwOL8j9s6EqsxmT+s+/E6Sw==",
+      "dependencies": {
+        "is-subdir": "^1.1.1",
+        "micromatch": "^4.0.8",
+        "spawndamnit": "^3.0.1",
+        "@changesets/errors": "^0.2.0",
+        "@manypkg/get-packages": "^1.1.3"
+      }
+    },
+    "node_modules/@changesets/logger": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@changesets/logger/-/logger-0.1.1.tgz",
+      "integrity": "sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg==",
+      "dependencies": {
+        "picocolors": "^1.1.0"
+      }
+    },
+    "node_modules/@changesets/parse": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.4.3.tgz",
+      "integrity": "sha512-ZDmNc53+dXdWEv7fqIUSgRQOLYoUom5Z40gmLgmATmYR9NbL6FJJHwakcCpzaeCy+1D0m0n7mT4jj2B/MQPl7A==",
+      "dependencies": {
+        "js-yaml": "^4.1.1",
+        "@changesets/types": "^6.1.0"
+      }
+    },
+    "node_modules/@changesets/pre": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-2.0.2.tgz",
+      "integrity": "sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug==",
+      "dependencies": {
+        "fs-extra": "^7.0.1",
+        "@changesets/types": "^6.1.0",
+        "@changesets/errors": "^0.2.0",
+        "@manypkg/get-packages": "^1.1.3"
+      }
+    },
+    "node_modules/@changesets/read": {
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.6.7.tgz",
+      "integrity": "sha512-D1G4AUYGrBEk8vj8MGwf75k9GpN6XL3wg8i42P2jZZwFLXnlr2Pn7r9yuQNbaMCarP7ZQWNJbV6XLeysAIMhTA==",
+      "dependencies": {
+        "fs-extra": "^7.0.1",
+        "p-filter": "^2.1.0",
+        "picocolors": "^1.1.0",
+        "@changesets/git": "^3.0.4",
+        "@changesets/parse": "^0.4.3",
+        "@changesets/types": "^6.1.0",
+        "@changesets/logger": "^0.1.1"
+      }
+    },
+    "node_modules/@changesets/should-skip-package": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@changesets/should-skip-package/-/should-skip-package-0.1.2.tgz",
+      "integrity": "sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw==",
+      "dependencies": {
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3"
+      }
+    },
+    "node_modules/@changesets/types": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-6.1.0.tgz",
+      "integrity": "sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA=="
+    },
+    "node_modules/@changesets/write": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@changesets/write/-/write-0.4.0.tgz",
+      "integrity": "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==",
+      "dependencies": {
+        "fs-extra": "^7.0.1",
+        "human-id": "^4.1.1",
+        "prettier": "^2.7.1",
+        "@changesets/types": "^6.1.0"
+      }
+    },
+    "node_modules/@changesets/write/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "bin": {
+        "prettier": "bin-prettier.js"
       }
     },
     "node_modules/@colors/colors": {
@@ -3834,11 +4038,6 @@
         "@inquirer/figures": "^1.0.15"
       }
     },
-    "node_modules/@inquirer/core/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
-    },
     "node_modules/@inquirer/core/node_modules/wrap-ansi": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -3863,6 +4062,15 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.0"
+      }
     },
     "node_modules/@inquirer/figures": {
       "version": "1.0.15",
@@ -3905,6 +4113,19 @@
         "at-least-node": "^1.0.0"
       }
     },
+    "node_modules/@ionic/utils-fs/node_modules/fs-extra/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-fs/node_modules/fs-extra/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="
+    },
     "node_modules/@ionic/utils-object": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/@ionic/utils-object/-/utils-object-2.1.6.tgz",
@@ -3926,6 +4147,11 @@
         "tree-kill": "^1.2.2",
         "tslib": "^2.0.1"
       }
+    },
+    "node_modules/@ionic/utils-process/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "node_modules/@ionic/utils-stream": {
       "version": "3.1.6",
@@ -3966,6 +4192,11 @@
         "untildify": "^4.0.0",
         "wrap-ansi": "^7.0.0"
       }
+    },
+    "node_modules/@ionic/utils-terminal/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "node_modules/@ionic/utils-terminal/node_modules/slice-ansi": {
       "version": "4.0.0",
@@ -4610,6 +4841,60 @@
       "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-3.5.1.tgz",
       "integrity": "sha512-qwosvPyl+zpUlp3gRb7UcJ3H8S28XHCzkv0Y0EgQToXjQP91ZD67EHSCDmaLjtKhe+GVIW5om1KUpzVLA0l6pg=="
     },
+    "node_modules/@manypkg/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@manypkg/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==",
+      "dependencies": {
+        "find-up": "^4.1.0",
+        "fs-extra": "^8.1.0",
+        "@types/node": "^12.7.1",
+        "@babel/runtime": "^7.5.5"
+      }
+    },
+    "node_modules/@manypkg/find-root/node_modules/@types/node": {
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
+    },
+    "node_modules/@manypkg/find-root/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dependencies": {
+        "jsonfile": "^4.0.0",
+        "graceful-fs": "^4.2.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "node_modules/@manypkg/get-packages": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@manypkg/get-packages/-/get-packages-1.1.3.tgz",
+      "integrity": "sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==",
+      "dependencies": {
+        "globby": "^11.0.0",
+        "fs-extra": "^8.1.0",
+        "@babel/runtime": "^7.5.5",
+        "read-yaml-file": "^1.1.0",
+        "@changesets/types": "^4.0.1",
+        "@manypkg/find-root": "^1.1.0"
+      }
+    },
+    "node_modules/@manypkg/get-packages/node_modules/@changesets/types": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-4.1.0.tgz",
+      "integrity": "sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw=="
+    },
+    "node_modules/@manypkg/get-packages/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dependencies": {
+        "jsonfile": "^4.0.0",
+        "graceful-fs": "^4.2.0",
+        "universalify": "^0.1.0"
+      }
+    },
     "node_modules/@marcj/ts-clone-node": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@marcj/ts-clone-node/-/ts-clone-node-2.2.0.tgz",
@@ -5195,6 +5480,22 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
       "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="
     },
+    "node_modules/@npmcli/git/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      }
+    },
+    "node_modules/@npmcli/git/node_modules/which/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw=="
+    },
     "node_modules/@npmcli/installed-package-contents": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-4.0.0.tgz",
@@ -5271,6 +5572,22 @@
       "dependencies": {
         "which": "^6.0.0"
       }
+    },
+    "node_modules/@npmcli/promise-spawn/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      }
+    },
+    "node_modules/@npmcli/promise-spawn/node_modules/which/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw=="
     },
     "node_modules/@npmcli/query": {
       "version": "5.0.0",
@@ -6767,15 +7084,15 @@
       "resolved": "https://registry.npmjs.org/@vue/babel-plugin-jsx/-/babel-plugin-jsx-2.0.1.tgz",
       "integrity": "sha512-a8CaLQjD/s4PVdhrLD/zT574ZNPnZBOY+IhdtKWRB4HRZ0I2tXBi5ne7d9eCfaYwp5gU5+4KIyFTV1W1YL9xZA==",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@vue/shared": "^3.5.22",
+        "@babel/types": "^7.28.4",
         "@babel/template": "^7.27.2",
         "@babel/traverse": "^7.28.4",
-        "@babel/types": "^7.28.4",
-        "@vue/shared": "^3.5.22",
-        "@vue/babel-helper-vue-transform-on": "2.0.1",
-        "@vue/babel-plugin-resolve-type": "2.0.1"
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-module-imports": "^7.27.1",
+        "@vue/babel-plugin-resolve-type": "2.0.1",
+        "@vue/babel-helper-vue-transform-on": "2.0.1"
       }
     },
     "node_modules/@vue/babel-plugin-resolve-type": {
@@ -6783,11 +7100,11 @@
       "resolved": "https://registry.npmjs.org/@vue/babel-plugin-resolve-type/-/babel-plugin-resolve-type-2.0.1.tgz",
       "integrity": "sha512-ybwgIuRGRRBhOU37GImDoWQoz+TlSqap65qVI6iwg/J7FfLTLmMf97TS7xQH9I7Qtr/gp161kYVdhr1ZMraSYQ==",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1",
         "@babel/parser": "^7.28.4",
-        "@vue/compiler-sfc": "^3.5.22"
+        "@babel/code-frame": "^7.27.1",
+        "@vue/compiler-sfc": "^3.5.22",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-module-imports": "^7.27.1"
       }
     },
     "node_modules/@vue/compiler-core": {
@@ -7196,6 +7513,11 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
+    },
     "node_modules/asn1js": {
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
@@ -7275,6 +7597,39 @@
       "integrity": "sha512-z8jt+EdS61AMw22nSfoNJAZ0vrtmhPRVi6ghL3rCeRZI8cdNYFiV5xeV3HbE7rlZZNmGH8BVccwWt8/ED0QOHA==",
       "dependencies": {
         "find-up": "^5.0.0"
+      }
+    },
+    "node_modules/babel-loader/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      }
+    },
+    "node_modules/babel-loader/node_modules/find-up/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      }
+    },
+    "node_modules/babel-loader/node_modules/find-up/node_modules/locate-path/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      }
+    },
+    "node_modules/babel-loader/node_modules/find-up/node_modules/locate-path/node_modules/p-locate/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
       }
     },
     "node_modules/babel-plugin-jsx-dom-expressions": {
@@ -7390,6 +7745,14 @@
         "dom-serializer": "^2.0.0",
         "postcss-safe-parser": "^7.0.1",
         "postcss-media-query-parser": "^0.2.3"
+      }
+    },
+    "node_modules/better-path-resolve": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/better-path-resolve/-/better-path-resolve-1.0.0.tgz",
+      "integrity": "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==",
+      "dependencies": {
+        "is-windows": "^1.0.0"
       }
     },
     "node_modules/big-integer": {
@@ -7525,11 +7888,11 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
       "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
         "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
+        "electron-to-chromium": "^1.5.328",
+        "update-browserslist-db": "^1.2.3",
+        "baseline-browser-mapping": "^2.10.12"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -7670,6 +8033,11 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
       "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="
+    },
+    "node_modules/chardet": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA=="
     },
     "node_modules/chevrotain": {
       "version": "7.1.1",
@@ -8145,22 +8513,6 @@
         "shebang-command": "^2.0.0"
       }
     },
-    "node_modules/cross-spawn/node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "./bin/node-which"
-      }
-    },
-    "node_modules/cross-spawn/node_modules/which/node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
-    },
     "node_modules/css-blank-pseudo": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/css-blank-pseudo/-/css-blank-pseudo-7.0.1.tgz",
@@ -8316,6 +8668,11 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
     },
+    "node_modules/detect-indent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA=="
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -8343,6 +8700,14 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
       "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A=="
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      }
     },
     "node_modules/dns-packet": {
       "version": "5.6.1",
@@ -8454,6 +8819,14 @@
         "iconv-lite": "^0.6.2"
       }
     },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -8469,6 +8842,15 @@
       "dependencies": {
         "tapable": "^2.3.3",
         "graceful-fs": "^4.2.4"
+      }
+    },
+    "node_modules/enquirer": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
+      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+      "dependencies": {
+        "ansi-colors": "^4.1.1",
+        "strip-ansi": "^6.0.1"
       }
     },
     "node_modules/entities": {
@@ -8742,11 +9124,6 @@
         "yoctocolors": "^2.1.1"
       }
     },
-    "node_modules/execa/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
-    },
     "node_modules/exif-parser": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
@@ -8817,6 +9194,11 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "node_modules/extendable-error": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz",
+      "integrity": "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -8920,11 +9302,11 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "dependencies": {
-        "locate-path": "^6.0.0",
+        "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
       }
     },
@@ -8983,13 +9365,13 @@
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
     },
     "node_modules/fs-extra": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
-      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
+        "jsonfile": "^4.0.0",
+        "graceful-fs": "^4.1.2",
+        "universalify": "^0.1.0"
       }
     },
     "node_modules/fs-minipass": {
@@ -9126,6 +9508,24 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dependencies": {
+        "slash": "^3.0.0",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "array-union": "^2.1.0"
+      }
+    },
+    "node_modules/globby/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -9382,6 +9782,14 @@
         "agent-base": "^7.1.2"
       }
     },
+    "node_modules/human-id": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/human-id/-/human-id-4.2.0.tgz",
+      "integrity": "sha512-K3GbkIWqyvvlpfhBPlbEvD97TtqBpAYA4kt+cn2lD2x2HuohzZCibcA2nOlnJT6exqvJLggoB5nv2dNf192nEA==",
+      "bin": {
+        "human-id": "dist/cli.js"
+      }
+    },
     "node_modules/human-signals": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
@@ -9393,9 +9801,9 @@
       "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A=="
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
@@ -9409,6 +9817,11 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="
     },
     "node_modules/ignore-walk": {
       "version": "8.0.0",
@@ -9452,6 +9865,11 @@
         "resolve-from": "^4.0.0",
         "parent-module": "^1.0.0"
       }
+    },
+    "node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -9669,11 +10087,6 @@
         "which": "./bin/which"
       }
     },
-    "node_modules/ios-sim-portable/node_modules/shelljs/node_modules/execa/node_modules/cross-spawn/node_modules/which/node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
-    },
     "node_modules/ios-sim-portable/node_modules/shelljs/node_modules/execa/node_modules/get-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -9699,6 +10112,11 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw=="
+    },
+    "node_modules/ios-sim-portable/node_modules/shelljs/node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "node_modules/ios-sim-portable/node_modules/yargs": {
       "version": "17.7.1",
@@ -9897,6 +10315,14 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
       "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="
     },
+    "node_modules/is-subdir": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-subdir/-/is-subdir-1.2.0.tgz",
+      "integrity": "sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==",
+      "dependencies": {
+        "better-path-resolve": "1.0.0"
+      }
+    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -9906,6 +10332,11 @@
       "version": "4.1.16",
       "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.16.tgz",
       "integrity": "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A=="
+    },
+    "node_modules/is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
     },
     "node_modules/is-wsl": {
       "version": "2.2.0",
@@ -9921,9 +10352,9 @@
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "node_modules/isexe": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
-      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/isobject": {
       "version": "3.0.1",
@@ -10065,11 +10496,11 @@
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="
     },
     "node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dependencies": {
-        "universalify": "^2.0.0"
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/jsonparse": {
@@ -10263,11 +10694,11 @@
       "integrity": "sha512-FMJTLMXfCLMLfJxcX9PFqX5qD88Z5MRGaZCVzfuqeZSPsyiBzs+pahDQjbIWz2QIzPZz0NX9Zy4FX3lmK6YHIg=="
     },
     "node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "dependencies": {
-        "p-locate": "^5.0.0"
+        "p-locate": "^4.1.0"
       }
     },
     "node_modules/lodash": {
@@ -10284,6 +10715,11 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "node_modules/lodash.startcase": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg=="
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -10330,11 +10766,6 @@
       "dependencies": {
         "mimic-function": "^5.0.0"
       }
-    },
-    "node_modules/log-update/node_modules/cli-cursor/node_modules/restore-cursor/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
     },
     "node_modules/log-update/node_modules/strip-ansi": {
       "version": "7.2.0",
@@ -11079,14 +11510,6 @@
         "minipass-sized": "^2.0.0"
       }
     },
-    "node_modules/minipass-fetch/node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      }
-    },
     "node_modules/minipass-flush": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
@@ -11152,6 +11575,11 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="
     },
     "node_modules/mrmime": {
       "version": "2.0.1",
@@ -11344,6 +11772,14 @@
         "mkdirp": "dist/cjs/src/bin.js"
       }
     },
+    "node_modules/nativescript/node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/nativescript/node_modules/typescript": {
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
@@ -11424,6 +11860,14 @@
         "needle": "bin/needle"
       }
     },
+    "node_modules/needle/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      }
+    },
     "node_modules/negotiator": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
@@ -11492,6 +11936,22 @@
       "version": "6.27.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
       "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg=="
+    },
+    "node_modules/node-gyp/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      }
+    },
+    "node_modules/node-gyp/node_modules/which/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw=="
     },
     "node_modules/node-releases": {
       "version": "2.0.48",
@@ -11688,6 +12148,11 @@
       "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.6.1.tgz",
       "integrity": "sha512-QkCdPooczexPLiXIrbVOPYkR3VO3T6v2OyKRkR1Xbhpy7/LAVXwahnRCgRp78Oe/Ehf0C/HATAxfSr6eA1oX+w=="
     },
+    "node_modules/outdent": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.5.0.tgz",
+      "integrity": "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q=="
+    },
     "node_modules/oxc-parser": {
       "version": "0.121.0",
       "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.121.0.tgz",
@@ -11720,25 +12185,38 @@
         "oxlint": "bin/oxlint"
       }
     },
+    "node_modules/p-filter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
+      "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
+      "dependencies": {
+        "p-map": "^2.0.0"
+      }
+    },
+    "node_modules/p-filter/node_modules/p-map": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
+    },
     "node_modules/p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow=="
     },
     "node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dependencies": {
-        "yocto-queue": "^0.1.0"
+        "p-try": "^2.0.0"
       }
     },
     "node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "dependencies": {
-        "p-limit": "^3.0.2"
+        "p-limit": "^2.2.0"
       }
     },
     "node_modules/p-map": {
@@ -11765,6 +12243,14 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+    },
+    "node_modules/package-manager-detector": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.11.tgz",
+      "integrity": "sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==",
+      "dependencies": {
+        "quansync": "^0.2.7"
+      }
     },
     "node_modules/pacote": {
       "version": "21.0.4",
@@ -11977,6 +12463,11 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA=="
     },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -12145,6 +12636,29 @@
       "bin": {
         "postcss": "index.js"
       }
+    },
+    "node_modules/postcss-cli/node_modules/fs-extra": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      }
+    },
+    "node_modules/postcss-cli/node_modules/fs-extra/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      }
+    },
+    "node_modules/postcss-cli/node_modules/fs-extra/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="
     },
     "node_modules/postcss-cli/node_modules/yargs": {
       "version": "17.7.3",
@@ -12667,6 +13181,11 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "node_modules/proper-lockfile/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
     "node_modules/property-information": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
@@ -12754,6 +13273,11 @@
         "side-channel": "^1.1.0"
       }
     },
+    "node_modules/quansync": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
+      "integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -12803,6 +13327,47 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-6.0.0.tgz",
       "integrity": "sha512-1zM5HuOfagXCBWMN83fuFI/x+T/UhZ7k+KIzhrHXcQoeX5+7gmaDYjELQHmmzIodumBHeByBJT4QYS7ufAgs7A=="
+    },
+    "node_modules/read-yaml-file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-yaml-file/-/read-yaml-file-1.1.0.tgz",
+      "integrity": "sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==",
+      "dependencies": {
+        "pify": "^4.0.1",
+        "js-yaml": "^3.6.1",
+        "strip-bom": "^3.0.0",
+        "graceful-fs": "^4.1.5"
+      }
+    },
+    "node_modules/read-yaml-file/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dependencies": {
+        "esprima": "^4.0.0",
+        "argparse": "^1.0.7"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/read-yaml-file/node_modules/js-yaml/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/read-yaml-file/node_modules/js-yaml/node_modules/argparse/node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+    },
+    "node_modules/read-yaml-file/node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",
@@ -13125,39 +13690,6 @@
         "string-width": "^4.1.0"
       }
     },
-    "node_modules/replace/node_modules/yargs/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      }
-    },
-    "node_modules/replace/node_modules/yargs/node_modules/find-up/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      }
-    },
-    "node_modules/replace/node_modules/yargs/node_modules/find-up/node_modules/locate-path/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      }
-    },
-    "node_modules/replace/node_modules/yargs/node_modules/find-up/node_modules/locate-path/node_modules/p-locate/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      }
-    },
     "node_modules/replace/node_modules/yargs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -13259,9 +13791,9 @@
       }
     },
     "node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
@@ -13308,6 +13840,11 @@
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
       }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "node_modules/retry": {
       "version": "0.12.0",
@@ -13456,9 +13993,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -13645,6 +14182,11 @@
         "path-key": "^3.0.0"
       }
     },
+    "node_modules/shelljs/node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
     "node_modules/shelljs/node_modules/execa/node_modules/strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -13700,9 +14242,9 @@
       }
     },
     "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
     },
     "node_modules/sigstore": {
       "version": "4.1.1",
@@ -13866,6 +14408,14 @@
         "source-map-js": "^1.0.2"
       }
     },
+    "node_modules/source-map-loader/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      }
+    },
     "node_modules/source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -13884,6 +14434,15 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
       "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="
+    },
+    "node_modules/spawndamnit": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spawndamnit/-/spawndamnit-3.0.1.tgz",
+      "integrity": "sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==",
+      "dependencies": {
+        "cross-spawn": "^7.0.5",
+        "signal-exit": "^4.0.1"
+      }
     },
     "node_modules/spdx-exceptions": {
       "version": "2.5.0",
@@ -13982,19 +14541,6 @@
         "universalify": "^0.1.0"
       }
     },
-    "node_modules/streamroller/node_modules/fs-extra/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/streamroller/node_modules/fs-extra/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
-    },
     "node_modules/string-width": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
@@ -14042,6 +14588,11 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="
     },
     "node_modules/strip-eof": {
       "version": "1.0.0",
@@ -14126,6 +14677,11 @@
         "minizlib": "^3.1.0",
         "@isaacs/fs-minipass": "^4.0.0"
       }
+    },
+    "node_modules/term-size": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
+      "integrity": "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg=="
     },
     "node_modules/terser": {
       "version": "5.46.0",
@@ -14482,9 +15038,9 @@
       }
     },
     "node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -14972,14 +15528,14 @@
       "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg=="
     },
     "node_modules/which": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
-      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dependencies": {
-        "isexe": "^4.0.0"
+        "isexe": "^2.0.0"
       },
       "bin": {
-        "node-which": "bin/which.js"
+        "node-which": "./bin/node-which"
       }
     },
     "node_modules/which-module": {
@@ -15032,11 +15588,6 @@
       "dependencies": {
         "signal-exit": "^4.0.1"
       }
-    },
-    "node_modules/write-file-atomic/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
     },
     "node_modules/ws": {
       "version": "8.21.0",

--- a/gjsify-sources.json
+++ b/gjsify-sources.json
@@ -750,6 +750,132 @@
   },
   {
     "type": "file",
+    "url": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.1.1.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/f6",
+    "dest-filename": "f6a3c29bfacbc7fc683855c81c6076dbdfb818e2fbe92e0c0beeedc8eb93b11ebed636257c50d039176fc11e610c0eb2e052f604fb77aa96dc4084be756f392c.tgz",
+    "sha512": "f6a3c29bfacbc7fc683855c81c6076dbdfb818e2fbe92e0c0beeedc8eb93b11ebed636257c50d039176fc11e610c0eb2e052f604fb77aa96dc4084be756f392c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.10.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/ad",
+    "dest-filename": "ad20dca9d27d29b5728e9048b8289d86f64d22256dd57688629ef7c9c5504480399ff8fac106849340a144b314435be4c597b9d4f4d0f4e2216e0e8740c5b8e4.tgz",
+    "sha512": "ad20dca9d27d29b5728e9048b8289d86f64d22256dd57688629ef7c9c5504480399ff8fac106849340a144b314435be4c597b9d4f4d0f4e2216e0e8740c5b8e4"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.2.1.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/c7",
+    "dest-filename": "c7fc4495e0852c7dbc7376d07902327997fc9455f20c5567d5281c0624764f0febe08016964d5fcf108467a3714008c5d8dc2d733a1e9f7380daa47e51ac10f1.tgz",
+    "sha512": "c7fc4495e0852c7dbc7376d07902327997fc9455f20c5567d5281c0624764f0febe08016964d5fcf108467a3714008c5d8dc2d733a1e9f7380daa47e51ac10f1"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@changesets/cli/-/cli-2.31.0.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/02",
+    "dest-filename": "0212387a7353807bb6219afa2b8599c9fd043dc8785d5327d7238c166083f60b1f046a8c61a1d796ce47c83bfafc22f96b1550001cfaf1e1b7d1e0ad6ebdb016.tgz",
+    "sha512": "0212387a7353807bb6219afa2b8599c9fd043dc8785d5327d7238c166083f60b1f046a8c61a1d796ce47c83bfafc22f96b1550001cfaf1e1b7d1e0ad6ebdb016"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@changesets/config/-/config-3.1.4.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/a5",
+    "dest-filename": "a5fd1bbc3fefe96236711959ea1ce98ed65d4a55c35cc009f88cfbc5f17357867127c38618038dfb5a9873df593eb8a39ede31a775461bb78dbc03864b6e15d5.tgz",
+    "sha512": "a5fd1bbc3fefe96236711959ea1ce98ed65d4a55c35cc009f88cfbc5f17357867127c38618038dfb5a9873df593eb8a39ede31a775461bb78dbc03864b6e15d5"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@changesets/errors/-/errors-0.2.0.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/e8",
+    "dest-filename": "e812ce414b1c4e965e1a58efc905e558e22d43253bd6409d1b3ecf8bc1fccddc3a048d20de6e3788be3129454f5ad1beaabacbf434e3a5d9fc798b82412469a3.tgz",
+    "sha512": "e812ce414b1c4e965e1a58efc905e558e22d43253bd6409d1b3ecf8bc1fccddc3a048d20de6e3788be3129454f5ad1beaabacbf434e3a5d9fc798b82412469a3"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-2.1.4.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/66",
+    "dest-filename": "66c4b4d31e96be61eadec42ff2808cc0bd1fff3df06d7095b925532700a79e66c2fe205d349185c7511c6cc1b83c2eac5d1c87ebd96233803658a5f39ff9113e.tgz",
+    "sha512": "66c4b4d31e96be61eadec42ff2808cc0bd1fff3df06d7095b925532700a79e66c2fe205d349185c7511c6cc1b83c2eac5d1c87ebd96233803658a5f39ff9113e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.16.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/d8",
+    "dest-filename": "d8ae4e9ba0ab30f9b8e6bb6f7247f35a8edef6339508a2c29d789ae5e50f694447eff2d6ceb8bba4ad53c9c77302e02d7a12e45bb54f6d62c2484c531e6888ea.tgz",
+    "sha512": "d8ae4e9ba0ab30f9b8e6bb6f7247f35a8edef6339508a2c29d789ae5e50f694447eff2d6ceb8bba4ad53c9c77302e02d7a12e45bb54f6d62c2484c531e6888ea"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@changesets/get-version-range-type/-/get-version-range-type-0.4.0.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/87",
+    "dest-filename": "8706b0b686fd0ebca8193a62c72d43dd95db1a026ed5186bfb2487d8fbd32c7be466e43bb114f8a10c0c87485ba991f5c1e028a1e7448d1b1bad67062c27b255.tgz",
+    "sha512": "8706b0b686fd0ebca8193a62c72d43dd95db1a026ed5186bfb2487d8fbd32c7be466e43bb114f8a10c0c87485ba991f5c1e028a1e7448d1b1bad67062c27b255"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@changesets/git/-/git-3.0.4.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/05",
+    "dest-filename": "05700dcd11645fe5dc0b5abf776ecd2af949d727fb3d20208bc246e9db7c11f6c71478b89de6aeee6b9f71271ae73461c0e2fc8fdb3a12ab31993facfbf13a4b.tgz",
+    "sha512": "05700dcd11645fe5dc0b5abf776ecd2af949d727fb3d20208bc246e9db7c11f6c71478b89de6aeee6b9f71271ae73461c0e2fc8fdb3a12ab31993facfbf13a4b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@changesets/logger/-/logger-0.1.1.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/39",
+    "dest-filename": "390b51dfa6659ee4f12aaa16e12bfac7960884e982951779a56b2366c75d631a56b39d7b4741e4ca279f40f232b42561e19702e71f57686f0a4dd7798914147e.tgz",
+    "sha512": "390b51dfa6659ee4f12aaa16e12bfac7960884e982951779a56b2366c75d631a56b39d7b4741e4ca279f40f232b42561e19702e71f57686f0a4dd7798914147e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@changesets/parse/-/parse-0.4.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/64",
+    "dest-filename": "64398d739dfe75775612fedfa8851281140e2d8a14a26e59e348262e09804e6611f4d6cbe852491f06a4702a7369e0b2fb50f49b49fb993e238f607f3103e5ec.tgz",
+    "sha512": "64398d739dfe75775612fedfa8851281140e2d8a14a26e59e348262e09804e6611f4d6cbe852491f06a4702a7369e0b2fb50f49b49fb993e238f607f3103e5ec"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@changesets/pre/-/pre-2.0.2.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/1d",
+    "dest-filename": "1da2ff804c8556f91ff4a160eb8f38c11f6cd2a8c05e567ca963c3913c8a17afb3aa305efc8da6ca083731ba59fbe85d8b44e8a8d505f1c8e3edf072d1d83c52.tgz",
+    "sha512": "1da2ff804c8556f91ff4a160eb8f38c11f6cd2a8c05e567ca963c3913c8a17afb3aa305efc8da6ca083731ba59fbe85d8b44e8a8d505f1c8e3edf072d1d83c52"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@changesets/read/-/read-0.6.7.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/0f",
+    "dest-filename": "0f51b8014606ac1124f2f8fc306c1fef993d1a937a5cbdf083c8b8d8fda3659c052d79e5af63e7eebf72b9035b68c09aacfed94163496d5e972decac0083214c.tgz",
+    "sha512": "0f51b8014606ac1124f2f8fc306c1fef993d1a937a5cbdf083c8b8d8fda3659c052d79e5af63e7eebf72b9035b68c09aacfed94163496d5e972decac0083214c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@changesets/should-skip-package/-/should-skip-package-0.1.2.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/a8",
+    "dest-filename": "a802bf5aba962cd08fdb65037414cc3c7e5fe357a554396c3726add7cd00df7756c6e503c8da60e9f3e2fc5c9367046b8958e0d0bf209e3267d85f57028174ab.tgz",
+    "sha512": "a802bf5aba962cd08fdb65037414cc3c7e5fe357a554396c3726add7cd00df7756c6e503c8da60e9f3e2fc5c9367046b8958e0d0bf209e3267d85f57028174ab"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@changesets/types/-/types-4.1.0.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/2c",
+    "dest-filename": "2c342f543bf929be749f2dacdb91619b777d4126629aca14181b148a88fa302dea6cc502b82f063c8be4fcce88bd7c77958840b3497059440b6fe5481140840b.tgz",
+    "sha512": "2c342f543bf929be749f2dacdb91619b777d4126629aca14181b148a88fa302dea6cc502b82f063c8be4fcce88bd7c77958840b3497059440b6fe5481140840b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@changesets/types/-/types-6.1.0.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/ac",
+    "dest-filename": "aca41c27ea359ca3607a86111ca392d3bb4030d777612374b876893996230408317d5ed3504ec913ecf807365d4306f984a6986dac8a3792ab615ece0dbdab00.tgz",
+    "sha512": "aca41c27ea359ca3607a86111ca392d3bb4030d777612374b876893996230408317d5ed3504ec913ecf807365d4306f984a6986dac8a3792ab615ece0dbdab00"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@changesets/write/-/write-0.4.0.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/09",
+    "dest-filename": "09d4cbbc838f88236e1fbd69c83bb7ac0f90d27eb972601b5e7c161fce2b286885ba61739261cd4fc2874cc11c85cc4df8a97c239e31194849ee5dc4ed7dfde9.tgz",
+    "sha512": "09d4cbbc838f88236e1fbd69c83bb7ac0f90d27eb972601b5e7c161fce2b286885ba61739261cd4fc2874cc11c85cc4df8a97c239e31194849ee5dc4ed7dfde9"
+  },
+  {
+    "type": "file",
     "url": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/a2",
     "dest-filename": "a28582ae564fd758bc1889928d31d81cb92f1433f8f274b8fb6d389c66f54625ff59760798903620823dfded8359569b08449d5bb841004cc746a527f4e515bd.tgz",
@@ -2549,6 +2675,13 @@
   },
   {
     "type": "file",
+    "url": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/45",
+    "dest-filename": "4566d2ac389898ee0b6de8d663bb6da71733bb043264b054cb282c03d36cbfde61a73516c27353550980ab7c6e87bbcdc02a74ed44e61398b5d57004131c7844.tgz",
+    "sha512": "4566d2ac389898ee0b6de8d663bb6da71733bb043264b054cb282c03d36cbfde61a73516c27353550980ab7c6e87bbcdc02a74ed44e61398b5d57004131c7844"
+  },
+  {
+    "type": "file",
     "url": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/b7",
     "dest-filename": "b7620463eba71873b301a54ce57c7a0c458a7979430dc34f783c94a6c45ce8252105f53755038497e56cb21ed5369d5d47c31d50905686e39b8d70ac5698cde6.tgz",
@@ -3085,6 +3218,20 @@
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/ab",
     "dest-filename": "ab0a2cbcfca5fb3a54969de045bed4709dc7f12dbc5c70b392fd18d048104e85e340ff75643ebb1074820e668b8ed2a17be195216e689b5294a7354b03497aa6.tgz",
     "sha512": "ab0a2cbcfca5fb3a54969de045bed4709dc7f12dbc5c70b392fd18d048104e85e340ff75643ebb1074820e668b8ed2a17be195216e689b5294a7354b03497aa6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@manypkg/find-root/-/find-root-1.1.0.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/9a",
+    "dest-filename": "9a48b9b81be11f33bc918622c7f591cb6597f12dc1e7075549cf43e8a714e6540d8253f6cade7cfd57cbb802b8f609515c2868b18f1aa76a09d6a8266b719454.tgz",
+    "sha512": "9a48b9b81be11f33bc918622c7f591cb6597f12dc1e7075549cf43e8a714e6540d8253f6cade7cfd57cbb802b8f609515c2868b18f1aa76a09d6a8266b719454"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@manypkg/get-packages/-/get-packages-1.1.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/7e",
+    "dest-filename": "7e8f9086e537a84ff64d031099b54ca9a43a1166cc862e000563fe3b800cd4da8f06ecb43ab0295792cee81aeb82786d0074b6347e91ad593d38bd7cd6d4e2f0.tgz",
+    "sha512": "7e8f9086e537a84ff64d031099b54ca9a43a1166cc862e000563fe3b800cd4da8f06ecb43ab0295792cee81aeb82786d0074b6347e91ad593d38bd7cd6d4e2f0"
   },
   {
     "type": "file",
@@ -5062,6 +5209,13 @@
   },
   {
     "type": "file",
+    "url": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/27",
+    "dest-filename": "27cc4bcfbab6385ba56767321932c4d536db65c8e99e8ec568deb374936b80076b27e0d9ce1fee151e98ad36f80be9d76a4bee77c438fab6e1a085a56106d415.tgz",
+    "sha512": "27cc4bcfbab6385ba56767321932c4d536db65c8e99e8ec568deb374936b80076b27e0d9ce1fee151e98ad36f80be9d76a4bee77c438fab6e1a085a56106d415"
+  },
+  {
+    "type": "file",
     "url": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/42",
     "dest-filename": "4292dc5fd652b2add86145270f79c50d8f07ef072d021423fd314a2fc61af2fe5f326dc2157c68f334adb0b025efcd25b68628a355af2945460502bed627ebee.tgz",
@@ -5594,6 +5748,13 @@
   },
   {
     "type": "file",
+    "url": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/a3",
+    "dest-filename": "a39468cbab4d1b848bfc53a408037a4738e26a4652db944b605adc32db49a9b75df015ab9c0f9f1b3e7b88de4f6f4ea9bc11af979810d01e3c74996c957be84e.tgz",
+    "sha512": "a39468cbab4d1b848bfc53a408037a4738e26a4652db944b605adc32db49a9b75df015ab9c0f9f1b3e7b88de4f6f4ea9bc11af979810d01e3c74996c957be84e"
+  },
+  {
+    "type": "file",
     "url": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/f3",
     "dest-filename": "f3ef56a9e6db173a57f4e47e59ae8edbd6ac22881e44ccdc1ad00835da4c1c7c80835d1fd3969215505b704a867ff3d7c35123019faadbf6c4060dc3beeacadd.tgz",
@@ -5605,6 +5766,13 @@
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/3c",
     "dest-filename": "3c254042cc167a6bba51dc6c0c5157ffe815798a8a0287770f75159bdd631f0ca782e3b002f60f871f2736533ef8da9170ae82c71a5469f8e684874a88789baa.tgz",
     "sha512": "3c254042cc167a6bba51dc6c0c5157ffe815798a8a0287770f75159bdd631f0ca782e3b002f60f871f2736533ef8da9170ae82c71a5469f8e684874a88789baa"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/1c",
+    "dest-filename": "1c6cb1a0e4d853208ceacb547ba1098277781287b0008ef331d7ea3be9068e79599810f3fdc479a5ff2bfdc4785aaeb4b0bfe9d0891c8d41043f04b7185ac8cb.tgz",
+    "sha512": "1c6cb1a0e4d853208ceacb547ba1098277781287b0008ef331d7ea3be9068e79599810f3fdc479a5ff2bfdc4785aaeb4b0bfe9d0891c8d41043f04b7185ac8cb"
   },
   {
     "type": "file",
@@ -5780,6 +5948,13 @@
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/d8",
     "dest-filename": "d8899d730dcbce70eec406c9336e911e788e2c0cc4e9682b2bc3aebd55c242d3414bcaec9c3f73b1211addf1e5e211e9518ec161396ba6fb4f55bbeef46ea77a.tgz",
     "sha512": "d8899d730dcbce70eec406c9336e911e788e2c0cc4e9682b2bc3aebd55c242d3414bcaec9c3f73b1211addf1e5e211e9518ec161396ba6fb4f55bbeef46ea77a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/better-path-resolve/-/better-path-resolve-1.0.0.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/a5",
+    "dest-filename": "a5b9e5e57cc605dac553fc13e23aa62553e7d81e941cf04e873310918fd23d43c1e90b545ed9811c123009b5c9a25f7798ea463274323fff81075f6ad38c63ee.tgz",
+    "sha512": "a5b9e5e57cc605dac553fc13e23aa62553e7d81e941cf04e873310918fd23d43c1e90b545ed9811c123009b5c9a25f7798ea463274323fff81075f6ad38c63ee"
   },
   {
     "type": "file",
@@ -6081,6 +6256,13 @@
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/88",
     "dest-filename": "881678178c116f239156cbb48cf57b81790eb066231873e6032bfe1e21c6f208b93ed0bd288da3d7ebfcfed9626d1be3a165f4dbbca9986fe7d07b4ee6deee9f.tgz",
     "sha512": "881678178c116f239156cbb48cf57b81790eb066231873e6032bfe1e21c6f208b93ed0bd288da3d7ebfcfed9626d1be3a165f4dbbca9986fe7d07b4ee6deee9f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/ad",
+    "dest-filename": "add75e95660d3d1ad7aba3ed3443764b77fab7d20bcefa9a379a55822e24aadf631d06972226a5f4fce70798923d595048b35a687db622d5b3dc426d435d3e38.tgz",
+    "sha512": "add75e95660d3d1ad7aba3ed3443764b77fab7d20bcefa9a379a55822e24aadf631d06972226a5f4fce70798923d595048b35a687db622d5b3dc426d435d3e38"
   },
   {
     "type": "file",
@@ -6651,6 +6833,13 @@
   },
   {
     "type": "file",
+    "url": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/ad",
+    "dest-filename": "ade6244d424065bf6052e67646f542361547760eb64479c9ed6265f1fb4c8b876267a35695c88ecd037cf295214842c4c1f94986de28403bf417404c970698b4.tgz",
+    "sha512": "ade6244d424065bf6052e67646f542361547760eb64479c9ed6265f1fb4c8b876267a35695c88ecd037cf295214842c4c1f94986de28403bf417404c970698b4"
+  },
+  {
+    "type": "file",
     "url": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/06",
     "dest-filename": "06d8f604e38ef37a375b21f9f5ef0c817b3111055c6ab9143a9118aee6c1d2eaf09cdd74c90dfae2bb22072535d67665a966199b4e62fe87fb8a8e26ce2841b5.tgz",
@@ -6690,6 +6879,13 @@
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/be",
     "dest-filename": "bed7037c7dd33a33fc51e932b6f9c71f5a353f815c51db78790d58f806daa75b64fce07631642f7304b60a509dd73b8885cdc928ec7aa7792877c55fcacdc4f8.tgz",
     "sha512": "bed7037c7dd33a33fc51e932b6f9c71f5a353f815c51db78790d58f806daa75b64fce07631642f7304b60a509dd73b8885cdc928ec7aa7792877c55fcacdc4f8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/5a",
+    "dest-filename": "5a4ad6a7d191e0a5df28663338b993b86562d545857f0b37efb9fd71ce79fed6fa0eeab217aa5c43901b88712c85a0e963dbfaa1a4abd9708389d1a633077320.tgz",
+    "sha512": "5a4ad6a7d191e0a5df28663338b993b86562d545857f0b37efb9fd71ce79fed6fa0eeab217aa5c43901b88712c85a0e963dbfaa1a4abd9708389d1a633077320"
   },
   {
     "type": "file",
@@ -6816,6 +7012,13 @@
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/68",
     "dest-filename": "68d9c60af6c9fd12325a8d48ba135d5639cd17e1231fdc29ce9347b7e722fe6f477bd2c9bd437cc2b09c5e3a7d716b06340baf4a95454f1fefada00543ca868d.tgz",
     "sha512": "68d9c60af6c9fd12325a8d48ba135d5639cd17e1231fdc29ce9347b7e722fe6f477bd2c9bd437cc2b09c5e3a7d716b06340baf4a95454f1fefada00543ca868d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/ad",
+    "dest-filename": "ad1a8983fea0779dfc547bd1dcf4ab75105bff5572d987f31eacef6e11884290d12886b816057fe786f9435c584b138ec0abe35f0792dba13443e9c0330a76a5.tgz",
+    "sha512": "ad1a8983fea0779dfc547bd1dcf4ab75105bff5572d987f31eacef6e11884290d12886b816057fe786f9435c584b138ec0abe35f0792dba13443e9c0330a76a5"
   },
   {
     "type": "file",
@@ -7176,6 +7379,13 @@
   },
   {
     "type": "file",
+    "url": "https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/50",
+    "dest-filename": "50e892da29fafd0d052b4474aba518f6f629436d66aff427d4a3a7b5eeefb000ae3497f9d785af08250749108f7208cf4f66c084d20976513a6d56a9d462a67a.tgz",
+    "sha512": "50e892da29fafd0d052b4474aba518f6f629436d66aff427d4a3a7b5eeefb000ae3497f9d785af08250749108f7208cf4f66c084d20976513a6d56a9d462a67a"
+  },
+  {
+    "type": "file",
     "url": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/7f",
     "dest-filename": "7f7a90f68432f63d808417bf1fd542f75c0b98a042094fe00ce9ca340606e61b303bb04b2a3d3d1dce4760dcfd70623efb19690c22200da8ad56cd3701347ce1.tgz",
@@ -7320,6 +7530,13 @@
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/78",
     "dest-filename": "78aa51280a2f76966d4755a8a4b1f19415af0203e7cb7738817d46e498709a6c385c98f489f483e6a0794cea3c866034c2544a0c0380844135c953e0b3a16072.tgz",
     "sha512": "78aa51280a2f76966d4755a8a4b1f19415af0203e7cb7738817d46e498709a6c385c98f489f483e6a0794cea3c866034c2544a0c0380844135c953e0b3a16072"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/60",
+    "dest-filename": "6090da0896449c199c6f0d777ef74033d03034e2703b3ac4e29a8ca81ab99c5884a9752a1f094ae01fb7a54c3a24dbdf48fb57d39c451ed632ff59e2d357860b.tgz",
+    "sha512": "6090da0896449c199c6f0d777ef74033d03034e2703b3ac4e29a8ca81ab99c5884a9752a1f094ae01fb7a54c3a24dbdf48fb57d39c451ed632ff59e2d357860b"
   },
   {
     "type": "file",
@@ -7481,6 +7698,13 @@
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/5a",
     "dest-filename": "5a3972ae89669bcb83a66fe8806c976576f567e09ad81f0d6c9c2a0558346b12bd19b05ea12ef2195eaf8d79d87469ba5f9de27a112ec716f288aa7c42637857.tgz",
     "sha512": "5a3972ae89669bcb83a66fe8806c976576f567e09ad81f0d6c9c2a0558346b12bd19b05ea12ef2195eaf8d79d87469ba5f9de27a112ec716f288aa7c42637857"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/8e",
+    "dest-filename": "8e121768ecf2d6c6fc232a1c6abb964a7d538e69c156cf00ca1732f37ae6c4d27cab6b96282023dc29c963e2a91925c2b9e00f7348b4e6456f54ab4fd6df52de.tgz",
+    "sha512": "8e121768ecf2d6c6fc232a1c6abb964a7d538e69c156cf00ca1732f37ae6c4d27cab6b96282023dc29c963e2a91925c2b9e00f7348b4e6456f54ab4fd6df52de"
   },
   {
     "type": "file",
@@ -7680,6 +7904,13 @@
   },
   {
     "type": "file",
+    "url": "https://registry.npmjs.org/human-id/-/human-id-4.2.0.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/2b",
+    "dest-filename": "2b719b9085aacafbe5a5f8413e56c4bc3f7b4eda81a40600e24b7e727da50f6c761eea21cd90a26dc0369ce967253e9ec6abc92e08280799efd9d35fd7dda710.tgz",
+    "sha512": "2b719b9085aacafbe5a5f8413e56c4bc3f7b4eda81a40600e24b7e727da50f6c761eea21cd90a26dc0369ce967253e9ec6abc92e08280799efd9d35fd7dda710"
+  },
+  {
+    "type": "file",
     "url": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/07",
     "dest-filename": "07814567aabf4f68e1864b2091b116dc706f5887c35bce6c9e44206b0b74ed2ec9e505d393a064355fb4c80799acce50a4c01d625a1c1a89639f4b09fd642417.tgz",
@@ -7740,6 +7971,13 @@
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/14",
     "dest-filename": "14278c653e0d89140687e62478a32d5ab3a60605a31e3309dba5905ab450ca8cb3a9ebdd68649a9146895b9c506268cb954564daa5270a361505ac7d10a2a0f0.tgz",
     "sha512": "14278c653e0d89140687e62478a32d5ab3a60605a31e3309dba5905ab450ca8cb3a9ebdd68649a9146895b9c506268cb954564daa5270a361505ac7d10a2a0f0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/86",
+    "dest-filename": "86c053354a904c3c245ad71d608da2d3a63f9d4044b0d10324a8d676280bbde832f240ee2404bcb91969924710a721172f467fa630f2e4706632344227682afa.tgz",
+    "sha512": "86c053354a904c3c245ad71d608da2d3a63f9d4044b0d10324a8d676280bbde832f240ee2404bcb91969924710a721172f467fa630f2e4706632344227682afa"
   },
   {
     "type": "file",
@@ -8044,6 +8282,13 @@
   },
   {
     "type": "file",
+    "url": "https://registry.npmjs.org/is-subdir/-/is-subdir-1.2.0.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/d8",
+    "dest-filename": "d804fa8fe8177bfd6e7aa6d6e9f2d9262230dc5f225c626db74c83ad96818406441b5ada893c4a594f883ea302cd001739408a740e140cc81a70a1f6e571b60b.tgz",
+    "sha512": "d804fa8fe8177bfd6e7aa6d6e9f2d9262230dc5f225c626db74c83ad96818406441b5ada893c4a594f883ea302cd001739408a740e140cc81a70a1f6e571b60b"
+  },
+  {
+    "type": "file",
     "url": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/92",
     "dest-filename": "927c46daae140b7bbcb2d446c8054908e771166bf90d989171d94868041701b49f2726be3a1a29368b4b42bb2d061aaeaaee19a6e29b0dcffc4ba9a05e03c53f.tgz",
@@ -8069,6 +8314,13 @@
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/66",
     "dest-filename": "661330128b1b149900d188459cd0e04cce19c4346c4ba1ea4e8eeab19334f1f7a1c9160861ad321eee51ea6828d67ffc32068f05788f8a63c3efb6da545620f8.tgz",
     "sha512": "661330128b1b149900d188459cd0e04cce19c4346c4ba1ea4e8eeab19334f1f7a1c9160861ad321eee51ea6828d67ffc32068f05788f8a63c3efb6da545620f8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/79",
+    "dest-filename": "7972b55089ead9b3e68f25fa7b754723330ba1b73827de22e005a7f87a6adce5392a4ad10bde8e01c4773d127fa46bba9bc4d19c11cff5d917415b13fc239520.tgz",
+    "sha512": "7972b55089ead9b3e68f25fa7b754723330ba1b73827de22e005a7f87a6adce5392a4ad10bde8e01c4773d127fa46bba9bc4d19c11cff5d917415b13fc239520"
   },
   {
     "type": "file",
@@ -8160,6 +8412,13 @@
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/45",
     "dest-filename": "45d2547e5704ddc5332a232a420b02bb4e853eef5474824ed1b7986cf84737893a6a9809b627dca02b53f5b7313a9601b690f690233a49bce0e026aeb16fcf29.tgz",
     "sha512": "45d2547e5704ddc5332a232a420b02bb4e853eef5474824ed1b7986cf84737893a6a9809b627dca02b53f5b7313a9601b690f690233a49bce0e026aeb16fcf29"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/3c",
+    "dest-filename": "3cc4a692ac6bd74e976b5e7a736336eb967e153acf97ea3177fae0390cb6b628d078ae53c50e37a6c3b5642c2154e49d9e7f91ce4ce5473fde638060241615a6.tgz",
+    "sha512": "3cc4a692ac6bd74e976b5e7a736336eb967e153acf97ea3177fae0390cb6b628d078ae53c50e37a6c3b5642c2154e49d9e7f91ce4ce5473fde638060241615a6"
   },
   {
     "type": "file",
@@ -8468,6 +8727,13 @@
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/d0",
     "dest-filename": "d0aa63a97455beb6320ac5f5b3047f5d32b4bdae9542440ce8c368ecfa96efb0728c086801103c11facfd4de3e2a52a3f184b46540ad453fd852e872603ba321.tgz",
     "sha512": "d0aa63a97455beb6320ac5f5b3047f5d32b4bdae9542440ce8c368ecfa96efb0728c086801103c11facfd4de3e2a52a3f184b46540ad453fd852e872603ba321"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/f9",
+    "dest-filename": "f962aab0adbde073127368c46cd8291e977425f201869eeb115e1aa975aa16be80957a2ff9295c801d45bf4d72da419edc673c9cc5bb540d12ac6b929117c812.tgz",
+    "sha512": "f962aab0adbde073127368c46cd8291e977425f201869eeb115e1aa975aa16be80957a2ff9295c801d45bf4d72da419edc673c9cc5bb540d12ac6b929117c812"
   },
   {
     "type": "file",
@@ -9101,6 +9367,13 @@
   },
   {
     "type": "file",
+    "url": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/b7",
+    "dest-filename": "b73cec91bddb1bc2ef606145fe60d3a6ade3a48e90f707372c49816a086ef83742b2c77515a90dec17348553661321aad5bab74607e409bddc9902e934f3aba0.tgz",
+    "sha512": "b73cec91bddb1bc2ef606145fe60d3a6ade3a48e90f707372c49816a086ef83742b2c77515a90dec17348553661321aad5bab74607e409bddc9902e934f3aba0"
+  },
+  {
+    "type": "file",
     "url": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/63",
     "dest-filename": "637c1074583655ae9eb6f43923cdb252119db0aadc628c7aa7b15f2f52db2b6278574d45f531a57a94c88672b6e2dee4a1989b9a0f36286825840d572b922c2d.tgz",
@@ -9479,6 +9752,13 @@
   },
   {
     "type": "file",
+    "url": "https://registry.npmjs.org/outdent/-/outdent-0.5.0.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/fe",
+    "dest-filename": "fe31f1148ce831776a3f34da0a91730005a1a644a364f17856c9fa8c07cda666c7ff29ac99ded073a544f411a7d0be98323eaec2940bc42102a6eb38ba4292f5.tgz",
+    "sha512": "fe31f1148ce831776a3f34da0a91730005a1a644a364f17856c9fa8c07cda666c7ff29ac99ded073a544f411a7d0be98323eaec2940bc42102a6eb38ba4292f5"
+  },
+  {
+    "type": "file",
     "url": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.121.0.tgz",
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/7a",
     "dest-filename": "7a4f68e7cf920afe8057b9dc86201c509cb50cd136082e5645d05c3b4985f96e284633507cf3bb6f7a4b8d31d21440a91e4286399490c71de193cbe220be580a.tgz",
@@ -9497,6 +9777,13 @@
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/0f",
     "dest-filename": "0fa2601edce4851c2f102f80d0dc390047396e4f31e62d691f3bd92047ff6b40b884ece600008d1ad90318fc856b1c57dd9546c423de8a0dcfdeb30cf17537fe.tgz",
     "sha512": "0fa2601edce4851c2f102f80d0dc390047396e4f31e62d691f3bd92047ff6b40b884ece600008d1ad90318fc856b1c57dd9546c423de8a0dcfdeb30cf17537fe"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/64",
+    "dest-filename": "641c71679b0bd878217a9861a46010768b24c69953c2bec809a7a16702c895f2fa69cb958193e6f3204db9100504612ab43fe19947aaf5ea8b836cacf57affcb.tgz",
+    "sha512": "641c71679b0bd878217a9861a46010768b24c69953c2bec809a7a16702c895f2fa69cb958193e6f3204db9100504612ab43fe19947aaf5ea8b836cacf57affcb"
   },
   {
     "type": "file",
@@ -9535,6 +9822,13 @@
   },
   {
     "type": "file",
+    "url": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/cb",
+    "dest-filename": "cb76fc2a977c380378e388717c16c57e3d4563f463b5377cb73630854a8d617c747d7c76897e2668fe10afaaa120a6d05c8d36c132c075ae1f6146c36a04d417.tgz",
+    "sha512": "cb76fc2a977c380378e388717c16c57e3d4563f463b5377cb73630854a8d617c747d7c76897e2668fe10afaaa120a6d05c8d36c132c075ae1f6146c36a04d417"
+  },
+  {
+    "type": "file",
     "url": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/b6",
     "dest-filename": "b64010130f32b0cce6921830f24fb553f88f856361ca42a74a4e11779ccba0f242b8968644fa3a629a2cad981ac472b30c774359666f13f4a4ee1b0bd97fc2a5.tgz",
@@ -9553,6 +9847,13 @@
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/47",
     "dest-filename": "4789cf0154c053407d0f7e7f1a4dee25fffb5d86d0732a2148a76f03121148d821165e1eef5855a069c1350cfd716697c4ed88d742930bede331dbefa0ac3a75.tgz",
     "sha512": "4789cf0154c053407d0f7e7f1a4dee25fffb5d86d0732a2148a76f03121148d821165e1eef5855a069c1350cfd716697c4ed88d742930bede331dbefa0ac3a75"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.11.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/04",
+    "dest-filename": "0449cba25bbecaecf6d92e7a094d5250aab75c2dcf9300f9c2fe22911e0c7c6be7455726cd747d0f04a55b67c46a6c933f25c7a2604947381aa5eb81bd137325.tgz",
+    "sha512": "0449cba25bbecaecf6d92e7a094d5250aab75c2dcf9300f9c2fe22911e0c7c6be7455726cd747d0f04a55b67c46a6c933f25c7a2604947381aa5eb81bd137325"
   },
   {
     "type": "file",
@@ -9742,6 +10043,13 @@
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/03",
     "dest-filename": "03f00634c14dddcf1b3a5bd5f51ade31daefee3b2617d5c87c378277cefe23c44d83ab3bf01849c4cbbaf4d10c1c14891712a275589311daee470124fd620aa8.tgz",
     "sha512": "03f00634c14dddcf1b3a5bd5f51ade31daefee3b2617d5c87c378277cefe23c44d83ab3bf01849c4cbbaf4d10c1c14891712a275589311daee470124fd620aa8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/80",
+    "dest-filename": "80329bf1a64c0de0ffb595acf4febeab427d33091d97ac4c57c4e39c63f7a89549d3a6dd32091b0652d4f0875f3ac22c173d815b5acd553dd7b8d125f333c0bf.tgz",
+    "sha512": "80329bf1a64c0de0ffb595acf4febeab427d33091d97ac4c57c4e39c63f7a89549d3a6dd32091b0652d4f0875f3ac22c173d815b5acd553dd7b8d125f333c0bf"
   },
   {
     "type": "file",
@@ -10361,6 +10669,13 @@
   },
   {
     "type": "file",
+    "url": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/02",
+    "dest-filename": "0227d3ed011b5bd36b8b8b40c11e4cfeece906ea9f65ffb3c1a10cfd09331238fb341b850f6ac1bb2d0addd13ef3096d6decc357b24c03459f9c23d845261b5c.tgz",
+    "sha512": "0227d3ed011b5bd36b8b8b40c11e4cfeece906ea9f65ffb3c1a10cfd09331238fb341b850f6ac1bb2d0addd13ef3096d6decc357b24c03459f9c23d845261b5c"
+  },
+  {
+    "type": "file",
     "url": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/36",
     "dest-filename": "36e68d49ae9f94a4f925a498433268934e09cd32f5080e9a1a1bf9adf2d6dcf82a03e3360a1a59427002f21f22e19164052f17e51aa40c11c0eebe217a3dcaf4.tgz",
@@ -10400,6 +10715,13 @@
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/d7",
     "dest-filename": "d733391ee39f6a05c205630df377ee148ff1f93fd4859ee4f8a23386b1d7710a1e5f9fbb82668362310b4079a6cc8a1dba6047781c81253e10612eee7c082cec.tgz",
     "sha512": "d733391ee39f6a05c205630df377ee148ff1f93fd4859ee4f8a23386b1d7710a1e5f9fbb82668362310b4079a6cc8a1dba6047781c81253e10612eee7c082cec"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/read-yaml-file/-/read-yaml-file-1.1.0.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/54",
+    "dest-filename": "548327422fd9e074f6171bb08392ab635ef853555d5080124155975f2aad351b714abf486249f5aec23a4dbe87b2b1c2981ee05693705fa2713d31dc1fa2284c.tgz",
+    "sha512": "548327422fd9e074f6171bb08392ab635ef853555d5080124155975f2aad351b714abf486249f5aec23a4dbe87b2b1c2981ee05693705fa2713d31dc1fa2284c"
   },
   {
     "type": "file",
@@ -10617,6 +10939,13 @@
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/a5",
     "dest-filename": "a5bfcc6265ecb40932b11171f2988d235b4614d408140def904dc6ab812e035745ea01e9ffebe066ab021896a9bf2f0ddd0fb8a3b170beab8f25c9d9ed1632e2.tgz",
     "sha512": "a5bfcc6265ecb40932b11171f2988d235b4614d408140def904dc6ab812e035745ea01e9ffebe066ab021896a9bf2f0ddd0fb8a3b170beab8f25c9d9ed1632e2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/a9",
+    "dest-filename": "a9883d28fdb8743e6a91af49e3b774695932d0df9be1f4d4f3d2cdf620e78c1e706a4b220b8f6bbcc0743eb509406a13987e745cf8aa3af0230df6a28c6c5867.tgz",
+    "sha512": "a9883d28fdb8743e6a91af49e3b774695932d0df9be1f4d4f3d2cdf620e78c1e706a4b220b8f6bbcc0743eb509406a13987e745cf8aa3af0230df6a28c6c5867"
   },
   {
     "type": "file",
@@ -11047,6 +11376,13 @@
   },
   {
     "type": "file",
+    "url": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/83",
+    "dest-filename": "83d43585a79bcb7e8e492b706f89ed08618668ab1a5528d0ebc7c1c6841cbad9797d2d6fb98d7c1f7c12b778c5c85b6b931f8acf45751bce40e0cc80743322d9.tgz",
+    "sha512": "83d43585a79bcb7e8e492b706f89ed08618668ab1a5528d0ebc7c1c6841cbad9797d2d6fb98d7c1f7c12b778c5c85b6b931f8acf45751bce40e0cc80743322d9"
+  },
+  {
+    "type": "file",
     "url": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/64",
     "dest-filename": "640ea84774ffa44caeab032000a4f4fe102ff28017724cdb926474524528b10f8c7384711a8264466c07807b9f69e9e5c80804d4cc60a5d72b7fbe72e977270e.tgz",
@@ -11152,6 +11488,13 @@
   },
   {
     "type": "file",
+    "url": "https://registry.npmjs.org/spawndamnit/-/spawndamnit-3.0.1.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/32",
+    "dest-filename": "3269ddb9052e1c2a057246685a75ec4e0ec96a22c126b2858fd508d8c6d13c6689795a6c2dc541bba3ff206668bf388cfd806c7a59429aca6b80d03ec340b356.tgz",
+    "sha512": "3269ddb9052e1c2a057246685a75ec4e0ec96a22c126b2858fd508d8c6d13c6689795a6c2dc541bba3ff206668bf388cfd806c7a59429aca6b80d03ec340b356"
+  },
+  {
+    "type": "file",
     "url": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/3e",
     "dest-filename": "3e2538dabfb13b851b512d5bba8dcb3c992394eef8df45e7e5254085da73cec3c7b236d855f9679c57404e069b9cbb9d7be0aabb6e69e8dfa0da5c3f3c5b1ae3.tgz",
@@ -11184,6 +11527,13 @@
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/af",
     "dest-filename": "af8ea065065057e2a5f6822dbe5d49659a89286afea04901d3c03a07392247be7ddffec86edba77171ddd98a18793b06e35e7b66cb0cbbd298bd41cb723703a0.tgz",
     "sha512": "af8ea065065057e2a5f6822dbe5d49659a89286afea04901d3c03a07392247be7ddffec86edba77171ddd98a18793b06e35e7b66cb0cbbd298bd41cb723703a0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/0f",
+    "dest-filename": "0fd70f824bcb955deddc8ccbd03d182ef180f40864e0f72f57051b3747521abd5a3f436bb780049d351bb86beab840b4980eb81aab757f38ab951b3989b5f1f2.tgz",
+    "sha512": "0fd70f824bcb955deddc8ccbd03d182ef180f40864e0f72f57051b3747521abd5a3f436bb780049d351bb86beab840b4980eb81aab757f38ab951b3989b5f1f2"
   },
   {
     "type": "file",
@@ -11299,6 +11649,13 @@
   },
   {
     "type": "file",
+    "url": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/bd",
+    "dest-filename": "bdabc03115ce80154d17a9f210498bdc304ad7d891a437282305beb3043e09b1a2bbb963bbab7e264940d4c1f07a85ad69d82de0849552c5cbc83ab7e1d75cc0.tgz",
+    "sha512": "bdabc03115ce80154d17a9f210498bdc304ad7d891a437282305beb3043e09b1a2bbb963bbab7e264940d4c1f07a85ad69d82de0849552c5cbc83ab7e1d75cc0"
+  },
+  {
+    "type": "file",
     "url": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/ec",
     "dest-filename": "ec50b01869b1f260f9c5077744f52f9d2a545c7337056bb38eda43e135ec7dc67d10be1acef55552c7056300fd9f1f0a87eb82042d345c1b40ca4a0c1f04e1f1.tgz",
@@ -11401,6 +11758,13 @@
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/05",
     "dest-filename": "0532dc2b4c6c0e1dbe3d47bd17a7364e5469e3338e04c4e4a101d0216488cc8d11eca1b8eae130ab838f9365bb6d9729ac132cb9a785b2ac18afba6387a0ae1e.tgz",
     "sha512": "0532dc2b4c6c0e1dbe3d47bd17a7364e5469e3338e04c4e4a101d0216488cc8d11eca1b8eae130ab838f9365bb6d9729ac132cb9a785b2ac18afba6387a0ae1e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/c0",
+    "dest-filename": "c0ad118b87ce1a3bff5cfcbc4811d90a197c08ceee31ce5530bed2aa2434cc6efe27956bf913100e81dad82353e8a1d49d31885c7df85033243f3014c9aa4166.tgz",
+    "sha512": "c0ad118b87ce1a3bff5cfcbc4811d90a197c08ceee31ce5530bed2aa2434cc6efe27956bf913100e81dad82353e8a1d49d31885c7df85033243f3014c9aa4166"
   },
   {
     "type": "file",

--- a/package.json
+++ b/package.json
@@ -404,7 +404,10 @@
     "format": "gjsify format --write",
     "fix": "gjsify fix",
     "lint": "gjsify lint",
-    "check:lint": "gjsify lint"
+    "check:lint": "gjsify lint",
+    "changeset": "changeset",
+    "changeset:version": "changeset version",
+    "changeset:publish": "gjsify workspace @learn6502/6502 build && changeset publish"
   },
   "author": "Pascal Garber <pascal@mailfreun.de>",
   "license": "GPL-3.0",
@@ -412,6 +415,7 @@
     "packages/*"
   ],
   "devDependencies": {
+    "@changesets/cli": "^2.27.0",
     "@gjsify/cli": "^0.10.0",
     "@gjsify/lightningcss-native": "^0.10.0",
     "@gjsify/rolldown-native": "^0.10.0",

--- a/packages/6502/package.json
+++ b/packages/6502/package.json
@@ -4,7 +4,7 @@
   "description": "6502 assembler and simulator in Javascript",
   "main": "dist/index.js",
   "type": "module",
-  "private": true,
+  "private": false,
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clear": "rm -rf dist",
@@ -16,5 +16,17 @@
   "devDependencies": {
     "@gjsify/cli": "^0.10.0",
     "typescript": "^6.0.3"
+  },
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JumpLink/Learn6502.git",
+    "directory": "packages/6502"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/app-android/package.json
+++ b/packages/app-android/package.json
@@ -12,8 +12,8 @@
     "check": "gjsify tsc --noEmit"
   },
   "dependencies": {
-    "@learn6502/6502": "workspace:^",
-    "@learn6502/common-ui": "workspace:^",
+    "@learn6502/6502": "^0.7.0",
+    "@learn6502/common-ui": "^0.7.0",
     "@nativescript/core": "~9.0.20",
     "@nativescript/localize": "^5.2.0",
     "@nativescript/tailwind": "^4.0.9",

--- a/packages/app-gnome/package.json
+++ b/packages/app-gnome/package.json
@@ -128,9 +128,9 @@
     "@girs/pango-1.0": "1.57.1-4.0.4",
     "@girs/webkit-6.0": "2.52.1-4.0.4",
     "@gjsify/storybook": "^0.10.0",
-    "@learn6502/6502": "workspace:^",
-    "@learn6502/common-ui": "workspace:^",
-    "@learn6502/learn": "workspace:^",
-    "@learn6502/translations": "workspace:^"
+    "@learn6502/6502": "^0.7.0",
+    "@learn6502/common-ui": "^0.7.0",
+    "@learn6502/learn": "^0.7.0",
+    "@learn6502/translations": "^0.7.0"
   }
 }

--- a/packages/app-web/package.json
+++ b/packages/app-web/package.json
@@ -24,6 +24,6 @@
     "vite": "^8.0.16"
   },
   "dependencies": {
-    "@learn6502/6502": "workspace:^"
+    "@learn6502/6502": "^0.7.0"
   }
 }

--- a/packages/common-ui/package.json
+++ b/packages/common-ui/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@learn6502/common-ui",
+  "private": true,
   "version": "0.7.0",
   "description": "Common UI components",
   "type": "module",
@@ -14,6 +15,6 @@
     "typescript": "^6.0.3"
   },
   "dependencies": {
-    "@learn6502/6502": "workspace:^"
+    "@learn6502/6502": "^0.7.0"
   }
 }

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@learn6502/examples",
+  "private": true,
   "version": "0.7.0",
   "description": "Learn 6502 assembly examples",
   "type": "module",
@@ -20,6 +21,6 @@
     "typescript": "^6.0.3"
   },
   "dependencies": {
-    "@learn6502/6502": "workspace:^"
+    "@learn6502/6502": "^0.7.0"
   }
 }

--- a/packages/learn/package.json
+++ b/packages/learn/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@learn6502/learn",
+  "private": true,
   "version": "0.7.0",
   "description": "Learn 6502 assembly",
   "type": "module",
@@ -47,6 +48,6 @@
     "typescript": "^6.0.3"
   },
   "dependencies": {
-    "@learn6502/examples": "workspace:^"
+    "@learn6502/examples": "^0.7.0"
   }
 }

--- a/packages/translations/package.json
+++ b/packages/translations/package.json
@@ -21,6 +21,6 @@
     "vite": "^8.0.16"
   },
   "dependencies": {
-    "@learn6502/learn": "workspace:^"
+    "@learn6502/learn": "^0.7.0"
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+# pnpm reads workspace members from this file (it does NOT read the package.json
+# "workspaces" field). Install behaviour (link-workspace-packages, node-linker)
+# lives in .npmrc.
+packages:
+  - "packages/*"


### PR DESCRIPTION
## Install with any package manager + set up npm publishing (Changesets)

Makes the monorepo installable with **npm, yarn, pnpm or gjsify**, and sets up npm publishing for `@learn6502/6502` via [Changesets].

### Why / what
- **Drop the `workspace:` protocol** → internal deps use plain `^0.7.0` ranges. npm and classic yarn can't resolve `workspace:` (only berry/pnpm/gjsify can); plain ranges work with **all** of npm/yarn/pnpm/gjsify (each symlinks the dep to the local workspace).
- **Changesets** (`fixed` group over `@learn6502/*`) bumps versions **and rewrites the internal `^` ranges automatically** — no hand-sync footgun. `@learn6502/6502` (the standalone, zero-dep core) is made **public**; `common-ui`/`examples`/`learn` flipped to `private` so **only 6502 publishes**. Adds `@changesets/cli` + `changeset`/`changeset:version`/`changeset:publish` scripts + `.changeset/config.json`.
- **6502 publish-readiness**: `types`/`files`/`repository`/`publishConfig: { access: public }`.
- **pnpm**: committed `pnpm-workspace.yaml` (pnpm ignores the `workspaces` field) + `.npmrc` with `link-workspace-packages=true` (pnpm 10 won't link local workspaces for plain ranges otherwise) and `node-linker=hoisted` (the strict layout breaks the gjsify bundler's `--globals auto`).
- **Manual `Package Managers` workflow** (`workflow_dispatch` + weekly cron, **never per-PR**) verifying npm/yarn/pnpm/gjsify each install + resolve the workspaces.
- **README**: install via npm/yarn/pnpm/gjsify (gjsify recommended) + a Releasing (Changesets) section.
- Regenerated `gjsify-lock.json` (+ the `@changesets/cli` subtree; **no existing dep bumped**) and `gjsify-sources.json` (+52 tarballs, purely additive — so the offline Flatpak build still installs).

### Verified (real install + build, isolated worktrees)
| PM | install | cross-workspace resolution / build |
|---|---|---|
| npm 11 | ✅ exit 0 | ✅ 6502 build + common-ui check (0 TS2307) |
| yarn v1 (1.22.22) | ✅ (was broken on `workspace:^`) | ✅ |
| pnpm 10 | ✅ (via `.npmrc`) | ✅ **full app-gnome build** (431 KB exe, no `Unsupported URI scheme` regression) |
| gjsify | ✅ | ✅ |

(The `.npmrc` pnpm keys are cosmetic-only for npm — "Unknown project config" warnings, install still exit 0 — and ignored by yarn/gjsify.)

### Note on publishing
This sets the repo **publish-ready**; the first `@learn6502/6502` npm publish (scope + auth/OIDC) is a maintainer step. After that, the Changesets flow (`changeset` → `changeset:version` → `changeset:publish`) takes over.

[Changesets]: https://github.com/changesets/changesets