### PR TITLE
fix: let pnpm run dep build scripts (ERR_PNPM_IGNORED_BUILDS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ npm run build && npm run start:gnome      # or the yarn / pnpm equivalent
 Notes:
 
 - **gjsify is the canonical path** — the committed `gjsify-lock.json` and the offline Flatpak build use it. npm/yarn/pnpm generate their own lockfiles (gitignored); they're fine for local dev, please don't commit them.
-- **pnpm** relies on the committed `pnpm-workspace.yaml` (pnpm reads its workspace members + settings there, not the `workspaces` field or a project `.npmrc`) — `linkWorkspacePackages: true` (so plain `^` ranges link the local workspaces) + `nodeLinker: hoisted` (flat layout the gjsify bundler needs).
+- **pnpm** relies on the committed `pnpm-workspace.yaml` (pnpm reads its workspace members + settings there, not the `workspaces` field or a project `.npmrc`): `linkWorkspacePackages: true` (plain `^` ranges link the local workspaces), `nodeLinker: hoisted` (flat layout the gjsify bundler needs), `minimumReleaseAge: 0` + `dangerouslyAllowAllBuilds: true` (match npm/yarn's defaults — no new-version quarantine, run dep build scripts — so non-interactive installs don't error).
 - The internal packages use plain `^x.y.z` ranges (not the `workspace:` protocol), which is why every manager — including npm and classic yarn — can resolve them.
 - A manual **Package Managers** CI workflow verifies all four managers install + resolve the workspaces; trigger it from the Actions tab if you touch the dependency wiring.
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,8 +13,13 @@
 # - minimumReleaseAge: 0 disables pnpm's new-version quarantine. The other PMs
 #   (npm/yarn/gjsify) have no such gate, so this keeps pnpm consistent and stops
 #   it blocking freshly-published @gjsify/* right after a gjsify release.
+# - dangerouslyAllowAllBuilds: pnpm 10 blocks dependency build scripts by default
+#   and exits non-zero (ERR_PNPM_IGNORED_BUILDS) in CI/non-interactive runs.
+#   npm and yarn RUN dep build scripts by default, so this just makes pnpm match
+#   them (the dep set is identical and already trusted under the other PMs).
 packages:
   - "packages/*"
 linkWorkspacePackages: true
 nodeLinker: hoisted
 minimumReleaseAge: 0
+dangerouslyAllowAllBuilds: true


### PR DESCRIPTION
Follow-up to #150/#151. The Package Managers workflow's **pnpm** leg now gets past the 404 + age gate (workspaces link) but exits 1 on `ERR_PNPM_IGNORED_BUILDS`: pnpm 10 blocks dependency build scripts by default and errors non-interactively. **npm and yarn run dep build scripts by default** (hence their green legs), so adding `dangerouslyAllowAllBuilds: true` to `pnpm-workspace.yaml` makes pnpm match them — identical, already-trusted dep set.

Verified in a clean `HOME` (mimics CI): `pnpm install` exits 0; the workflow's check (build `@learn6502/6502` → check `@learn6502/common-ui`) exits 0. Only touches `pnpm-workspace.yaml` + the README note.