### PR TITLE
Web: common-ui DebuggerView spike (ADR 0007)

### DIFF
--- a/gjsify-lock.json
+++ b/gjsify-lock.json
@@ -43,6 +43,7 @@
     "@gjsify/storybook@^0.10.0",
     "@gjsify/vite-plugin-blueprint@^0.10.0",
     "@gjsify/vite-plugin-gettext@^0.10.0",
+    "@gjsify/adwaita-web@^0.14.0",
     "lightningcss@^1.32.0",
     "@types/node@^25.9.1",
     "@gjsify/dom-elements@^0.10.0",
@@ -1565,6 +1566,15 @@
         "@gjsify/adwaita-fonts": "^0.14.0",
         "@gjsify/adwaita-icons": "^0.14.0",
         "@gjsify/native-platform": "^0.14.0"
+      }
+    },
+    "node_modules/@gjsify/adwaita-web": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/adwaita-web/-/adwaita-web-0.14.0.tgz",
+      "integrity": "sha512-jiU7EJrtgc6bMesHNmMJ3vBomHY/kIlSTTNhS9mkH0yzlDVdcAl60ohSoqgpzpNqX4h8002QXjfJqO7RvYZVVw==",
+      "dependencies": {
+        "@gjsify/adwaita-fonts": "^0.14.0",
+        "@gjsify/adwaita-icons": "^0.14.0"
       }
     },
     "node_modules/@gjsify/assert": {

--- a/packages/app-web/.gitignore
+++ b/packages/app-web/.gitignore
@@ -1,1 +1,2 @@
 _site
+dist-spike

--- a/packages/app-web/README.md
+++ b/packages/app-web/README.md
@@ -23,6 +23,23 @@ To run the web version locally, execute the following commands:
 
 This will serve the site at http://localhost:4000.
 
+### DebuggerView spike (ADR 0007)
+
+`debugger-spike.html` is a dev-only page (not linked from the Jekyll site) that
+renders `AdwDebuggerView` — the shared `DebuggerView` interface from
+`@learn6502/common-ui` implemented over `@gjsify/adwaita-web` custom elements,
+driven by the same `debuggerController` the GNOME and Android apps use. Open it
+with:
+
+```
+    npx vite                    # dev server → http://localhost:5173/debugger-spike.html
+    # or, after `gjsify run build` (spike bundles to dist-spike/, kept out of the site):
+    npx vite preview --config vite.spike.config.js
+```
+
+The classic widget on the simulator page is untouched — the spike view lives
+alongside it (see `src/views/adw-debugger.ts` and `src/widgets/debugger/`).
+
 ## License
 
 This package is licensed under the [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/), maintaining the original license from Nick Morgan's work.

--- a/packages/app-web/debugger-spike.html
+++ b/packages/app-web/debugger-spike.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Learn 6502 — DebuggerView spike (ADR 0007)</title>
+    <style>
+      /* Dev-only spike page chrome; everything else is styled by adwaita-web.
+         The adwaita-web skin themes via CSS variables (auto light/dark through
+         prefers-color-scheme) but expects the window container — normally an
+         <adw-window> — to paint the root surface. This page has no window
+         chrome, so bind the body to the same tokens. */
+      :root {
+        color-scheme: light dark;
+      }
+      body {
+        margin: 0;
+        background: var(--window-bg-color, #fafafb);
+        color: var(--window-fg-color, rgb(0 0 6 / 80%));
+        font-family: "Adwaita Sans", "Cantarell", sans-serif;
+      }
+      main {
+        max-width: 700px;
+        margin: 0 auto;
+        padding: 12px 12px 48px;
+      }
+      .learn-spike-editor {
+        display: block;
+        width: 100%;
+        box-sizing: border-box;
+        min-height: 180px;
+        margin-bottom: 12px;
+        padding: 10px 14px;
+        font-family: ui-monospace, "Adwaita Mono", monospace;
+        font-size: 0.9em;
+        border-radius: 12px;
+        border: 1px solid var(--border-color, rgb(0 0 0 / 15%));
+        background: var(--view-bg-color, #fff);
+        color: var(--view-fg-color, #000);
+        resize: vertical;
+      }
+      .learn-spike-toolbar {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+      .learn-spike-state {
+        margin-left: auto;
+        opacity: 0.6;
+        font-size: 0.85em;
+      }
+    </style>
+  </head>
+  <body>
+    <script type="module" src="/src/debugger-spike.ts"></script>
+  </body>
+</html>

--- a/packages/app-web/package.json
+++ b/packages/app-web/package.json
@@ -6,10 +6,11 @@
   "private": true,
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "clear": "rm -rf dist _site",
+    "clear": "rm -rf dist dist-spike _site",
     "setup": "gem install bundler jekyll && bundle install",
     "build:vite": "vite build",
-    "build": "gjsify run build:vite",
+    "build:spike": "vite build --config vite.spike.config.js",
+    "build": "gjsify run build:vite && gjsify run build:spike",
     "check": "gjsify tsc --noEmit",
     "start:app": "gjsify run dist/main.js",
     "debug:app": "GTK_DEBUG=interactive gjsify run dist/main.js",
@@ -24,6 +25,8 @@
     "vite": "^8.0.16"
   },
   "dependencies": {
+    "@gjsify/adwaita-web": "^0.14.0",
+    "@learn6502/common-ui": "^0.7.0",
     "@learn6502/core": "^0.7.0"
   }
 }

--- a/packages/app-web/src/debugger-spike.ts
+++ b/packages/app-web/src/debugger-spike.ts
@@ -1,0 +1,140 @@
+/**
+ * ADR 0007 spike demo page — drives the `AdwDebuggerView` through the SAME
+ * common-ui pipeline the GNOME and Android apps use:
+ *
+ *   core events → gameConsoleController → GameConsoleEventBridge (shared)
+ *     → AdwDebuggerView → debuggerController → widgets
+ *
+ * No controller logic is re-implemented here: the page only builds the demo
+ * chrome (program editor + toolbar) and forwards button clicks to
+ * `gameConsoleController`, exactly like the twins' main views.
+ *
+ * Dev-only — not linked from the Jekyll site. Open via:
+ *   npx vite            → http://localhost:5173/debugger-spike.html
+ *   npx vite preview    → after `gjsify run build`
+ */
+
+import "@gjsify/adwaita-web";
+import { AdwButton, AdwHeaderBar, AdwToastOverlay, AdwWindowTitle } from "@gjsify/adwaita-web";
+import { DebuggerState, GameConsoleEventBridge, debuggerController, gameConsoleController } from "@learn6502/common-ui";
+import { Assembler, Labels, Memory, Simulator, formatMessage } from "@learn6502/core";
+
+import { AdwDebuggerView } from "./views/adw-debugger.js";
+
+/** Notification key → toast title (the GNOME twin's NOTIFICATION_TITLES, English only). */
+const NOTIFICATION_TITLES: Record<string, string> = {
+  "assembled-successfully": "Assembled successfully",
+  "assemble-failed": "Assemble failed",
+  "simulator-failure": "Simulator failure",
+  "labels-failure": "Labels failure",
+  "program-completed": "Program completed",
+};
+
+const DEMO_PROGRAM = `; Fill the display page at $0200 with random colors.
+; Select the "Display Memory" region in the hex monitor
+; to watch the writes happen.
+  LDX #$00
+loop:
+  LDA $fe        ; random byte
+  STA $0200,X
+  INX
+  BNE loop
+  BRK
+`;
+
+// --- Core setup (what GameConsole does on every platform) ---
+const memory = new Memory();
+const labels = new Labels();
+const simulator = new Simulator(memory, labels);
+const assembler = new Assembler(memory, labels);
+
+// --- Page chrome ---
+const overlay = new AdwToastOverlay();
+
+const headerBar = new AdwHeaderBar();
+const windowTitle = new AdwWindowTitle();
+windowTitle.setAttribute("slot", "center");
+windowTitle.setAttribute("title", "DebuggerView spike");
+windowTitle.setAttribute("subtitle", "common-ui × adwaita-web (ADR 0007)");
+headerBar.appendChild(windowTitle);
+
+const main = document.createElement("main");
+
+const editor = document.createElement("textarea");
+editor.className = "learn-spike-editor";
+editor.spellcheck = false;
+editor.value = DEMO_PROGRAM;
+
+const toolbar = document.createElement("div");
+toolbar.className = "learn-spike-toolbar";
+
+const stateLabel = document.createElement("span");
+stateLabel.className = "learn-spike-state";
+stateLabel.textContent = simulator.state;
+
+function toolbarButton(label: string, onClick: () => void, suggested = false): AdwButton {
+  const button = new AdwButton();
+  button.setAttribute("label", label);
+  if (suggested) button.setAttribute("suggested", "");
+  button.addEventListener("click", onClick);
+  toolbar.appendChild(button);
+  return button;
+}
+
+toolbarButton("Assemble", () => gameConsoleController.assemble(editor.value), true);
+toolbarButton("Run", () => gameConsoleController.run());
+toolbarButton("Stop", () => gameConsoleController.stop());
+toolbarButton("Step", () => gameConsoleController.step());
+toolbarButton("Reset", () => {
+  gameConsoleController.reset();
+  view.reset();
+});
+toolbar.appendChild(stateLabel);
+
+// --- The spike view ---
+const view = new AdwDebuggerView();
+
+main.append(editor, toolbar, view);
+overlay.append(headerBar, main);
+document.body.appendChild(overlay);
+
+// --- Wire the shared controller layer (same seam as GNOME/Android) ---
+gameConsoleController.initPartial({ memory, simulator, assembler, labels });
+view.initialize(assembler, simulator);
+// The debugger page is always visible here — mark it active (the Android twin
+// does the same in its screen's onShow).
+view.state = DebuggerState.ACTIVE;
+
+const bridge = new GameConsoleEventBridge({
+  formatAndLog: (message, params) => {
+    // Web: English only, printf-style substitution via formatMessage
+    debuggerController.log(formatMessage(message, params ?? []));
+  },
+  updateDebugger: () => {
+    view.update(memory, simulator);
+  },
+  updateAssemblerViews: (asm) => {
+    view.updateHexdump(asm);
+    view.updateDisassembled(asm);
+  },
+  updateUiState: (state) => {
+    stateLabel.textContent = state ?? simulator.state;
+  },
+  showNotification: (key) => {
+    overlay.addToast(NOTIFICATION_TITLES[key] ?? key);
+  },
+  updateDebugInfo: () => {
+    if (simulator.stepperEnabled) view.update(memory, simulator);
+  },
+});
+bridge.connect();
+
+// Platform-level handling of controller events the view leaves to the host
+// (the Android twin routes this to its editor via mainStateController).
+debuggerController.on("copyToEditor", (code: string) => {
+  editor.value = code;
+  overlay.addToast("Code copied to editor");
+});
+debuggerController.on("copyToClipboard", () => {
+  overlay.addToast("Copied to clipboard");
+});

--- a/packages/app-web/src/types/adwaita-fonts.d.ts
+++ b/packages/app-web/src/types/adwaita-fonts.d.ts
@@ -1,0 +1,6 @@
+// Workaround (spike finding, feeds gjsify ADR 0004): @gjsify/adwaita-fonts
+// declares `"types": "./index.d.ts"` in its exports map but does not ship that
+// file (its entry point is CSS, fontsource-style). Declare the module so the
+// side-effect import in @gjsify/adwaita-web's declarations type-checks.
+// Remove once the gjsify-side packaging is fixed.
+declare module "@gjsify/adwaita-fonts";

--- a/packages/app-web/src/views/adw-debugger.ts
+++ b/packages/app-web/src/views/adw-debugger.ts
@@ -1,0 +1,212 @@
+import { AdwClamp, AdwPreferencesGroup, AdwSwitchRow } from "@gjsify/adwaita-web";
+import type { DebuggerView, DisassembledCopyEvent, HexdumpCopyEvent, HexMonitorCopyEvent } from "@learn6502/common-ui";
+import { DebuggerState, debuggerController } from "@learn6502/common-ui";
+import type { Assembler, Memory, Simulator } from "@learn6502/core";
+
+import { DebugInfo, Disassembled, HexMonitor, Hexdump, MessageConsole } from "../widgets/debugger/index.js";
+
+/**
+ * AdwDebuggerView — the ADR 0007 spike: `DebuggerView` from
+ * `@learn6502/common-ui` implemented as a class over `@gjsify/adwaita-web`
+ * custom elements, wired to the shared `debuggerController` exactly like its
+ * GNOME (`Debugger extends Adw.Bin`) and Android (`Debugger` over
+ * `@gjsify/adwaita-nativescript`) twins.
+ *
+ * Structure mirrors the twins: a clamped column with a "Debug Settings" boxed
+ * list (enable + stepper switch rows), the register/flags display, and the
+ * hex monitor / hexdump / disassembled / messages sections. All logic stays in
+ * `debuggerController`; this class only builds widgets and forwards events.
+ */
+export class AdwDebuggerView extends HTMLElement implements DebuggerView {
+  private messageConsole: MessageConsole | null = null;
+  private debugInfo: DebugInfo | null = null;
+  private hexMonitor: HexMonitor | null = null;
+  private hexdump: Hexdump | null = null;
+  private disassembled: Disassembled | null = null;
+  private enabledRow: AdwSwitchRow | null = null;
+  private stepperRow: AdwSwitchRow | null = null;
+
+  // Reference to the last memory update for refreshing when monitor options change
+  private memory: Memory | null = null;
+  private subscribed = false;
+
+  private onStateChanged = (state: DebuggerState): void => {
+    if (!this.enabledRow) return;
+    const shouldBeEnabled = state !== DebuggerState.DISABLED;
+    if (this.enabledRow.active !== shouldBeEnabled) this.enabledRow.active = shouldBeEnabled;
+  };
+
+  private onStepperToggled = (enabled: boolean): void => {
+    if (!this.stepperRow) return;
+    if (this.stepperRow.active !== enabled) this.stepperRow.active = enabled;
+  };
+
+  private onCopyToClipboard = (content: string): void => {
+    void navigator.clipboard?.writeText(content);
+  };
+
+  public get state(): DebuggerState {
+    return debuggerController.state;
+  }
+
+  public set state(value: DebuggerState) {
+    debuggerController.state = value;
+  }
+
+  connectedCallback(): void {
+    this.ensureBuilt();
+  }
+
+  /**
+   * Initialize the shared controller with this view's widgets and the core
+   * references — the same `debuggerController.init(...)` call the GNOME and
+   * Android views make.
+   */
+  public initialize(assembler: Assembler, simulator: Simulator): void {
+    this.ensureBuilt();
+
+    debuggerController.init(
+      this.messageConsole!,
+      this.debugInfo!,
+      assembler,
+      simulator,
+      this.hexMonitor!,
+      this.disassembled!,
+      this.hexdump!
+    );
+
+    if (!this.subscribed) {
+      this.subscribed = true;
+      debuggerController.on("stateChanged", this.onStateChanged);
+      debuggerController.on("stepperToggled", this.onStepperToggled);
+      debuggerController.on("copyToClipboard", this.onCopyToClipboard);
+    }
+
+    // Seed the switch rows from the controller state.
+    this.onStateChanged(debuggerController.state);
+    this.onStepperToggled(debuggerController.stepperEnabled);
+  }
+
+  // --- DebuggerView interface (delegates to debuggerController, like the twins) ---
+
+  public update(memory: Memory, simulator: Simulator): void {
+    this.memory = memory;
+    debuggerController.update(memory, simulator);
+  }
+
+  public updateMonitor(memory: Memory): void {
+    debuggerController.updateMonitor(memory);
+  }
+
+  public updateDebugInfo(simulator: Simulator): void {
+    debuggerController.updateDebugInfo(simulator);
+  }
+
+  public updateHexdump(assembler: Assembler): void {
+    debuggerController.updateHexdump(assembler);
+  }
+
+  public updateDisassembled(assembler: Assembler): void {
+    debuggerController.updateDisassembled(assembler);
+  }
+
+  public log(message: string): void {
+    debuggerController.log(message);
+  }
+
+  public reset(): void {
+    debuggerController.reset();
+  }
+
+  public close(): void {
+    if (this.subscribed) {
+      this.subscribed = false;
+      debuggerController.off("stateChanged", this.onStateChanged);
+      debuggerController.off("stepperToggled", this.onStepperToggled);
+      debuggerController.off("copyToClipboard", this.onCopyToClipboard);
+    }
+    debuggerController.close();
+  }
+
+  /** Build the widget tree (once) and wire widget events to the controller. */
+  private ensureBuilt(): void {
+    if (this.messageConsole) return;
+
+    this.messageConsole = new MessageConsole();
+    this.debugInfo = new DebugInfo();
+    this.hexMonitor = new HexMonitor();
+    this.hexdump = new Hexdump();
+    this.disassembled = new Disassembled();
+
+    const column = document.createElement("div");
+
+    // --- Debug Settings (Adwaita boxed list, like the GNOME/Android twins) ---
+    const settings = new AdwPreferencesGroup();
+    settings.setAttribute("title", "Debug Settings");
+
+    this.enabledRow = new AdwSwitchRow();
+    this.enabledRow.setAttribute("title", "Enable debugger");
+    this.enabledRow.active = debuggerController.state !== DebuggerState.DISABLED;
+    this.enabledRow.addEventListener("notify::active", () => {
+      debuggerController.state = this.enabledRow?.active ? DebuggerState.ACTIVE : DebuggerState.DISABLED;
+    });
+    settings.appendChild(this.enabledRow);
+
+    this.stepperRow = new AdwSwitchRow();
+    this.stepperRow.setAttribute("title", "Stepping mode");
+    this.stepperRow.active = debuggerController.stepperEnabled;
+    this.stepperRow.addEventListener("notify::active", () => {
+      debuggerController.stepperEnabled = this.stepperRow?.active ?? false;
+    });
+    settings.appendChild(this.stepperRow);
+
+    column.appendChild(settings);
+
+    // --- Widget sections, in the GNOME debugger order: registers, hex monitor,
+    //     hexdump, disassembled, then messages. The register/flags display is
+    //     an Adwaita boxed list (its own groups); the rest get a heading. ---
+    column.appendChild(this.debugInfo);
+    column.appendChild(this.section("Hex Monitor", this.hexMonitor));
+    column.appendChild(this.section("Hexdump", this.hexdump));
+    column.appendChild(this.section("Disassembled", this.disassembled));
+    column.appendChild(this.section("Messages", this.messageConsole));
+
+    this.setupWidgetEventListeners();
+
+    const clamp = new AdwClamp();
+    clamp.setAttribute("maximum-size", "700");
+    clamp.appendChild(column);
+    this.replaceChildren(clamp);
+  }
+
+  /** A heading + the widget, matching the Android twin's section helper. */
+  private section(title: string, content: HTMLElement): HTMLElement {
+    const wrap = document.createElement("div");
+    wrap.className = "learn-section";
+
+    const heading = document.createElement("span");
+    heading.className = "learn-section-heading";
+    heading.textContent = title;
+
+    wrap.append(heading, content);
+    return wrap;
+  }
+
+  /** Wire widget copy/changed events to the controller (like both twins). */
+  private setupWidgetEventListeners(): void {
+    this.disassembled?.events.on("copy", (event: DisassembledCopyEvent) => {
+      debuggerController.copyToEditor(event.code);
+    });
+    this.hexdump?.events.on("copy", (event: HexdumpCopyEvent) => {
+      debuggerController.copyToClipboard(event.content);
+    });
+    this.hexMonitor?.events.on("copy", (event: HexMonitorCopyEvent) => {
+      debuggerController.copyToClipboard(event.content);
+    });
+    this.hexMonitor?.events.on("changed", () => {
+      if (this.memory) debuggerController.updateMonitor(this.memory);
+    });
+  }
+}
+
+customElements.define("learn-debugger", AdwDebuggerView);

--- a/packages/app-web/src/widgets/debugger/code-card.ts
+++ b/packages/app-web/src/widgets/debugger/code-card.ts
@@ -1,0 +1,31 @@
+import { AdwButton, AdwCard } from "@gjsify/adwaita-web";
+
+/** The parts of a monospace code card with a floating copy button. */
+export interface CodeCard {
+  card: AdwCard;
+  code: HTMLElement;
+  copyButton: AdwButton;
+}
+
+/**
+ * Build an `<adw-card>` wrapping a `<pre><code>` block with a flat copy button
+ * in the top-right corner — the web idiom for the copy affordance the GNOME
+ * SourceView button and the Android tap-to-copy gesture provide.
+ */
+export function buildCodeCard(copyTooltip: string): CodeCard {
+  const card = new AdwCard();
+  card.className = "learn-code-card";
+
+  const pre = document.createElement("pre");
+  const code = document.createElement("code");
+  pre.appendChild(code);
+
+  const copyButton = new AdwButton();
+  copyButton.className = "learn-copy-button";
+  copyButton.setAttribute("icon", "edit-copy");
+  copyButton.setAttribute("flat", "");
+  copyButton.setAttribute("tooltip", copyTooltip);
+
+  card.append(pre, copyButton);
+  return { card, code, copyButton };
+}

--- a/packages/app-web/src/widgets/debugger/debug-info.ts
+++ b/packages/app-web/src/widgets/debugger/debug-info.ts
@@ -1,0 +1,132 @@
+import { AdwActionRow, AdwPreferencesGroup } from "@gjsify/adwaita-web";
+import type { DebugInfoWidget } from "@learn6502/common-ui";
+import type { Simulator } from "@learn6502/core";
+import { addr2hex, num2hex } from "@learn6502/core";
+
+/** A register row's two value labels (hex on top, decimal dim below). */
+interface RegisterValue {
+  hex: HTMLSpanElement;
+  dec: HTMLSpanElement;
+}
+
+/**
+ * DebugInfo — 6502 CPU registers and the status-flag bits, rendered as Adwaita
+ * boxed lists (`<adw-preferences-group>` + `<adw-action-row>`) to match the
+ * GNOME debugger (`debug-info.blp`) and its NativeScript twin: a "Registers"
+ * group with five rows (A/X/Y/SP/PC, each showing `$hex` over a dim decimal),
+ * and a "Status Flags" group whose single row carries the N V - B D I Z C bit
+ * display in its suffix.
+ */
+export class DebugInfo extends HTMLElement implements DebugInfoWidget {
+  private registers: Map<string, RegisterValue> | null = null;
+
+  /** Bit labels p7..p0 (N V - B D I Z C), dimmed when the bit is 0. */
+  private bitLabels: HTMLSpanElement[] = [];
+
+  connectedCallback(): void {
+    this.ensureBuilt();
+  }
+
+  public update(simulator: Simulator): void {
+    this.ensureBuilt();
+    const { regA, regX, regY, regP, regPC, regSP } = simulator.info;
+
+    this.setValue("A", `$${num2hex(regA)}`, regA);
+    this.setValue("X", `$${num2hex(regX)}`, regX);
+    this.setValue("Y", `$${num2hex(regY)}`, regY);
+    this.setValue("SP", `$${num2hex(regSP)}`, regSP);
+    this.setValue("PC", `$${addr2hex(regPC)}`, regPC);
+
+    // Flags N V - B D I Z C (bit7..bit0); dim a bit when it is 0.
+    for (let i = 0; i < 8; i++) {
+      const value = (regP >> (7 - i)) & 1;
+      const label = this.bitLabels[i];
+      label.textContent = value ? "1" : "0";
+      label.classList.toggle("learn-flag-off", value === 0);
+    }
+  }
+
+  private ensureBuilt(): void {
+    if (this.registers) return;
+    this.registers = new Map();
+
+    const registers = new AdwPreferencesGroup();
+    registers.setAttribute("title", "Registers");
+
+    this.addRegisterRow(registers, "A", "Accumulator: Main register for calculations");
+    this.addRegisterRow(registers, "X", "Index register X: Used for addressing");
+    this.addRegisterRow(registers, "Y", "Index register Y: Used for addressing");
+    this.addRegisterRow(registers, "SP", "Stack Pointer: Points to stack position");
+    this.addRegisterRow(registers, "PC", "Program Counter: Points to next instruction");
+
+    const flags = new AdwPreferencesGroup();
+    flags.setAttribute("title", "Status Flags");
+
+    const flagsRow = new AdwActionRow();
+    flagsRow.setAttribute("title", "P (SR)");
+    flagsRow.setAttribute("subtitle", "Processor Status Register");
+    flagsRow.appendChild(this.buildFlagsGrid());
+    flags.appendChild(flagsRow);
+
+    this.replaceChildren(registers, flags);
+  }
+
+  /** Add an `<adw-action-row>` for a register and remember its value labels. */
+  private addRegisterRow(group: AdwPreferencesGroup, name: string, subtitle: string): void {
+    const row = new AdwActionRow();
+    row.setAttribute("title", name);
+    row.setAttribute("subtitle", subtitle);
+
+    const box = document.createElement("div");
+    box.setAttribute("slot", "suffix");
+    box.className = "learn-register-value";
+
+    const hex = document.createElement("span");
+    hex.textContent = "$00";
+
+    const dec = document.createElement("span");
+    dec.className = "learn-register-dec";
+    dec.textContent = "0";
+
+    box.append(hex, dec);
+    row.appendChild(box);
+
+    group.appendChild(row);
+    this.registers?.set(name, { hex, dec });
+  }
+
+  /** The compact N V - B D I Z C header + bit display shown in the flags row suffix. */
+  private buildFlagsGrid(): HTMLDivElement {
+    const grid = document.createElement("div");
+    grid.setAttribute("slot", "suffix");
+    grid.className = "learn-flags-grid";
+
+    const headers = ["N", "V", "-", "B", "D", "I", "Z", "C"];
+    for (const text of headers) {
+      const header = document.createElement("span");
+      header.className = "learn-flag-header";
+      header.textContent = text;
+      grid.appendChild(header);
+    }
+
+    this.bitLabels = [];
+    for (let col = 0; col < 8; col++) {
+      const bit = document.createElement("span");
+      bit.textContent = "0";
+      bit.classList.add("learn-flag-off");
+      grid.appendChild(bit);
+      this.bitLabels.push(bit);
+    }
+
+    return grid;
+  }
+
+  private setValue(name: string, hex: string, dec: number): void {
+    const target = this.registers?.get(name);
+    if (!target) return;
+    target.hex.textContent = hex;
+    target.dec.textContent = `${dec}`;
+  }
+}
+
+customElements.define("learn-debug-info", DebugInfo);

--- a/packages/app-web/src/widgets/debugger/disassembled.ts
+++ b/packages/app-web/src/widgets/debugger/disassembled.ts
@@ -1,0 +1,42 @@
+import type { DisassembledEventMap, DisassembledWidget } from "@learn6502/common-ui";
+import type { Assembler } from "@learn6502/core";
+import { EventDispatcher } from "@learn6502/core";
+import { buildCodeCard } from "./code-card.js";
+
+/**
+ * Disassembled — disassembly of the assembled program.
+ *
+ * Web twin of app-android's `Disassembled extends TextView` and app-gnome's
+ * `disassembled.blp`: a monospace code card whose copy button dispatches the
+ * disassembled code (routed to the editor by the controller).
+ *
+ * @emits copy - when the user copies the disassembled code
+ */
+export class Disassembled extends HTMLElement implements DisassembledWidget {
+  readonly events = new EventDispatcher<DisassembledEventMap>();
+
+  private output: HTMLElement | null = null;
+  private lastCode = "";
+
+  connectedCallback(): void {
+    this.ensureBuilt();
+  }
+
+  public update(assembler: Assembler): void {
+    this.ensureBuilt();
+    this.lastCode = assembler.disassemble().formatted;
+    if (this.output) this.output.textContent = this.lastCode;
+  }
+
+  private ensureBuilt(): void {
+    if (this.output) return;
+    const { card, code, copyButton } = buildCodeCard("Copy to editor");
+    this.output = code;
+    copyButton.addEventListener("click", () => {
+      if (this.lastCode) this.events.dispatch("copy", { code: this.lastCode });
+    });
+    this.replaceChildren(card);
+  }
+}
+
+customElements.define("learn-disassembled", Disassembled);

--- a/packages/app-web/src/widgets/debugger/hex-monitor.ts
+++ b/packages/app-web/src/widgets/debugger/hex-monitor.ts
@@ -1,0 +1,96 @@
+import { AdwComboRow, AdwPreferencesGroup } from "@gjsify/adwaita-web";
+import type { HexMonitorEventMap, HexMonitorOptions, HexMonitorWidget, MemoryRegion } from "@learn6502/common-ui";
+import { memoryRegions } from "@learn6502/common-ui";
+import type { Memory } from "@learn6502/core";
+import { EventDispatcher } from "@learn6502/core";
+import { buildCodeCard } from "./code-card.js";
+
+/**
+ * HexMonitor — live memory view with a selectable memory region.
+ *
+ * Web twin of app-gnome's `hex-monitor.blp` (region dropdown + source view)
+ * and app-android's `HexMonitor extends ScrollView`. The region select is an
+ * `<adw-combo-row>` fed from the shared `memoryRegions` data; the dump is a
+ * monospace code card with a copy button.
+ *
+ * @emits changed - when the selected memory region changes
+ * @emits copy - when the user copies the monitor content
+ */
+export class HexMonitor extends HTMLElement implements HexMonitorWidget {
+  readonly events = new EventDispatcher<HexMonitorEventMap>();
+
+  readonly memoryRegions: MemoryRegion[] = memoryRegions;
+
+  public options: HexMonitorOptions = {
+    // Initial selection mirrors the GNOME debugger: Zero Page.
+    start: 0x0000,
+    length: 0x0100,
+  };
+
+  private output: HTMLElement | null = null;
+  private lastContent = "";
+
+  connectedCallback(): void {
+    this.ensureBuilt();
+  }
+
+  public update(memory: Memory): void {
+    this.ensureBuilt();
+    const { start, length } = this.options;
+    const end = start + length - 1;
+    let content: string;
+
+    if (!isNaN(start) && !isNaN(length) && start >= 0 && length > 0 && end <= 0xffff) {
+      content = memory.format({
+        start,
+        length,
+        includeAddress: true,
+        includeSpaces: true,
+        includeNewline: true,
+      });
+    } else {
+      content = "Cannot monitor this range. Valid ranges are between $0000 and $ffff, inclusive.";
+    }
+
+    this.lastContent = content;
+    if (this.output) this.output.textContent = content;
+  }
+
+  public setMonitorRange(start: number, length: number): void {
+    this.options.start = start;
+    this.options.length = length;
+  }
+
+  private ensureBuilt(): void {
+    if (this.output) return;
+
+    const group = new AdwPreferencesGroup();
+
+    const regionRow = new AdwComboRow();
+    regionRow.setAttribute("title", "Memory region");
+    regionRow.setAttribute("items", JSON.stringify(this.memoryRegions.map((region) => region.name)));
+    regionRow.setAttribute("selected", "0");
+    regionRow.addEventListener("notify::selected", (event) => {
+      const { selected } = (event as CustomEvent<{ selected: number }>).detail;
+      this.applySelectedRegion(selected);
+    });
+    group.appendChild(regionRow);
+
+    const { card, code, copyButton } = buildCodeCard("Copy memory dump");
+    this.output = code;
+    copyButton.addEventListener("click", () => {
+      if (this.lastContent) this.events.dispatch("copy", { content: this.lastContent });
+    });
+
+    this.replaceChildren(group, card);
+  }
+
+  private applySelectedRegion(selectedIndex: number): void {
+    if (selectedIndex < 0 || selectedIndex >= this.memoryRegions.length) return;
+    const region = this.memoryRegions[selectedIndex];
+    this.setMonitorRange(region.start, region.length);
+    this.events.dispatch("changed", { content: this.lastContent, region });
+  }
+}
+
+customElements.define("learn-hex-monitor", HexMonitor);

--- a/packages/app-web/src/widgets/debugger/hexdump.ts
+++ b/packages/app-web/src/widgets/debugger/hexdump.ts
@@ -1,0 +1,45 @@
+import type { HexdumpEventMap, HexdumpWidget } from "@learn6502/common-ui";
+import type { Assembler } from "@learn6502/core";
+import { EventDispatcher } from "@learn6502/core";
+import { buildCodeCard } from "./code-card.js";
+
+/**
+ * Hexdump — hexdump of the assembled program.
+ *
+ * Web twin of app-android's `Hexdump extends TextView` and app-gnome's
+ * `hexdump.blp`: a monospace code card with a copy button.
+ *
+ * @emits copy - when the user copies the hexdump content
+ */
+export class Hexdump extends HTMLElement implements HexdumpWidget {
+  readonly events = new EventDispatcher<HexdumpEventMap>();
+
+  private output: HTMLElement | null = null;
+  private lastContent = "";
+
+  connectedCallback(): void {
+    this.ensureBuilt();
+  }
+
+  public update(assembler: Assembler): void {
+    this.ensureBuilt();
+    this.lastContent = assembler.hexdump({
+      includeAddress: true,
+      includeSpaces: true,
+      includeNewline: true,
+    });
+    if (this.output) this.output.textContent = this.lastContent;
+  }
+
+  private ensureBuilt(): void {
+    if (this.output) return;
+    const { card, code, copyButton } = buildCodeCard("Copy hexdump");
+    this.output = code;
+    copyButton.addEventListener("click", () => {
+      if (this.lastContent) this.events.dispatch("copy", { content: this.lastContent });
+    });
+    this.replaceChildren(card);
+  }
+}
+
+customElements.define("learn-hexdump", Hexdump);

--- a/packages/app-web/src/widgets/debugger/index.ts
+++ b/packages/app-web/src/widgets/debugger/index.ts
@@ -1,0 +1,8 @@
+import "./styles.js";
+
+export * from "./code-card.js";
+export * from "./debug-info.js";
+export * from "./disassembled.js";
+export * from "./hex-monitor.js";
+export * from "./hexdump.js";
+export * from "./message-console.js";

--- a/packages/app-web/src/widgets/debugger/message-console.ts
+++ b/packages/app-web/src/widgets/debugger/message-console.ts
@@ -1,0 +1,55 @@
+import type { MessageConsoleWidget } from "@learn6502/common-ui";
+
+/**
+ * MessageConsole — auto-scrolling monospace message log for the debugger.
+ *
+ * Web twin of app-android's `MessageConsole extends TextView` and app-gnome's
+ * `message-console.blp`: a custom element wrapping a `<pre><code>` block.
+ * All logic stays in `debuggerController`; this widget only renders text.
+ */
+export class MessageConsole extends HTMLElement implements MessageConsoleWidget {
+  private output: HTMLElement | null = null;
+
+  connectedCallback(): void {
+    this.ensureBuilt();
+  }
+
+  public log(message: string): void {
+    this.appendLine(message);
+  }
+
+  public warn(message: string): void {
+    this.appendLine(`⚠ ${message}`);
+  }
+
+  public error(message: string): void {
+    this.appendLine(`✗ ${message}`);
+  }
+
+  public clear(): void {
+    this.ensureBuilt().textContent = "";
+  }
+
+  public prompt(message: string, defaultValue?: string): string | null {
+    return window.prompt(message, defaultValue);
+  }
+
+  private ensureBuilt(): HTMLElement {
+    if (this.output) return this.output;
+    const pre = document.createElement("pre");
+    this.output = document.createElement("code");
+    pre.appendChild(this.output);
+    this.replaceChildren(pre);
+    return this.output;
+  }
+
+  private appendLine(message: string): void {
+    const output = this.ensureBuilt();
+    output.textContent += `${message}\n`;
+    // Keep the newest message visible (the <pre> is the scroll container).
+    const pre = output.parentElement;
+    if (pre) pre.scrollTop = pre.scrollHeight;
+  }
+}
+
+customElements.define("learn-message-console", MessageConsole);

--- a/packages/app-web/src/widgets/debugger/styles.ts
+++ b/packages/app-web/src/widgets/debugger/styles.ts
@@ -1,0 +1,76 @@
+/**
+ * Shared stylesheet for the common-ui debugger widgets (ADR 0007 spike).
+ * Self-injected on import — the same pattern `@gjsify/adwaita-web` uses for
+ * its own skin, so a single side-effect import styles all debugger widgets.
+ * Only spike-specific chrome lives here (code blocks, copy button, flag grid);
+ * everything else comes from the adwaita-web skin.
+ */
+
+const DEBUGGER_CSS = /* css */ `
+learn-debugger {
+  display: block;
+}
+
+learn-debugger .learn-section-heading {
+  display: block;
+  font-weight: bold;
+  margin: 18px 0 8px;
+}
+
+learn-debugger .learn-code-card {
+  position: relative;
+  display: block;
+  padding: 10px 14px;
+}
+
+learn-debugger .learn-code-card pre {
+  margin: 0;
+  max-height: 240px;
+  overflow: auto;
+  font-family: ui-monospace, "Adwaita Mono", monospace;
+  font-size: 0.85em;
+  line-height: 1.45;
+  white-space: pre;
+}
+
+learn-debugger .learn-copy-button {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+}
+
+learn-debugger .learn-register-value {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  font-family: ui-monospace, "Adwaita Mono", monospace;
+}
+
+learn-debugger .learn-register-value .learn-register-dec {
+  opacity: 0.55;
+  font-size: 0.8em;
+}
+
+learn-debugger .learn-flags-grid {
+  display: grid;
+  grid-template-columns: repeat(8, 1.2em);
+  justify-items: center;
+  font-family: ui-monospace, "Adwaita Mono", monospace;
+}
+
+learn-debugger .learn-flags-grid .learn-flag-header {
+  opacity: 0.55;
+  font-size: 0.8em;
+}
+
+learn-debugger .learn-flag-off {
+  opacity: 0.4;
+}
+`;
+
+if (typeof document !== "undefined" && !document.getElementById("learn-debugger-style")) {
+  const style = document.createElement("style");
+  style.id = "learn-debugger-style";
+  style.textContent = DEBUGGER_CSS;
+  document.head.appendChild(style);
+}

--- a/packages/app-web/tsconfig.json
+++ b/packages/app-web/tsconfig.json
@@ -5,6 +5,17 @@
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "paths": {
+      // Workaround (spike finding, feeds gjsify ADR 0004): the published
+      // @gjsify/adwaita-web points its exports "types" at src/index.ts, but the
+      // shipped src is missing styles.generated.ts and @gjsify/adwaita-fonts
+      // ships no index.d.ts — type-checking the TS source fails (TS2882/TS7016).
+      // The package DOES ship built declarations under lib/types, so remap the
+      // type resolution there until the gjsify-side packaging is fixed.
+      // Vite ignores tsconfig paths, so the runtime import still uses the real
+      // package entry.
+      "@gjsify/adwaita-web": ["../../node_modules/@gjsify/adwaita-web/lib/types/index.d.ts"]
+    },
     "allowImportingTsExtensions": true,
     "noEmit": true,
     "strict": true,
@@ -14,5 +25,5 @@
     "alwaysStrict": true,
     "diagnostics": true
   },
-  "files": ["src/main.ts"]
+  "files": ["src/main.ts", "src/debugger-spike.ts", "src/types/adwaita-fonts.d.ts"]
 }

--- a/packages/app-web/vite.spike.config.js
+++ b/packages/app-web/vite.spike.config.js
@@ -1,0 +1,27 @@
+import { defineConfig } from "vite";
+
+// Dev-only build for the ADR 0007 DebuggerView spike (debugger-spike.html).
+//
+// This is a SEPARATE config on purpose: the main build is consumed by the
+// Jekyll site through classic (non-module) <script> tags, so it must stay a
+// single self-contained chunk. Adding the spike page as a second entry to the
+// main config would split shared modules into an extra chunk loaded via
+// `import` — which a classic script cannot execute. Building the spike into
+// its own output dir keeps the published site byte-identical.
+//
+// The dev server does not need this config (no bundling): `npx vite` serves
+// /debugger-spike.html directly.
+export default defineConfig({
+  clearScreen: false,
+  css: {
+    transformer: "lightningcss",
+  },
+  build: {
+    outDir: "dist-spike",
+    minify: false,
+    rollupOptions: {
+      input: ["debugger-spike.html"],
+    },
+    cssMinify: "lightningcss",
+  },
+});


### PR DESCRIPTION
## Spike (dev-only, additive) — gjsify ADR 0007

This is the bounded spike from gjsify **ADR 0007** ("Web targets implement the shared controller/view layer"). It implements the smallest shared view interface — `DebuggerView` from `@learn6502/common-ui` — in `app-web` as a class over `@gjsify/adwaita-web` custom elements, driven by the **existing** `debuggerController`, to test whether the controller/view layer is genuinely platform-neutral or actually GTK/NS-shaped.

**Nothing is replaced.** The classic web debugger on the simulator page is untouched. The spike lives alongside it and is only reachable through a dev-only page.

### What's here

- `src/views/adw-debugger.ts` — `AdwDebuggerView implements DebuggerView`, wired to `debuggerController` exactly like the GNOME (`Debugger extends Adw.Bin`) and Android (`Debugger` over `@gjsify/adwaita-nativescript`) twins.
- `src/widgets/debugger/` — web twins of the five debugger widget interfaces: `MessageConsole`, `DebugInfo` (registers + status-flag grid as `<adw-preferences-group>`/`<adw-action-row>`), `HexMonitor` (`<adw-combo-row>` region select + code card), `Hexdump`, `Disassembled`. Plus a small `code-card` helper (monospace `<pre>` in an `<adw-card>` with a flat copy `<adw-button>`) and a self-injected `styles.ts`.
- `debugger-spike.html` + `src/debugger-spike.ts` — dev-only demo page. Drives the view through the **same** seam the apps use: `gameConsoleController.initPartial(...)` + the shared `GameConsoleEventBridge` → `AdwDebuggerView` → `debuggerController` → widgets.
- Built via a separate `vite.spike.config.js` into `dist-spike/` (git-ignored) so the published Jekyll site output stays byte-identical.

### How to run

```
cd packages/app-web
npx vite                                   # dev → http://localhost:5173/debugger-spike.html
# or, after `gjsify run build`:
npx vite preview --config vite.spike.config.js
```

## FINDING

**Verdict: SUCCESS on all three ADR-0007 criteria. Recommend adopting per-view migration (follow-up PRs, no big-bang).**

### Criterion (a): no changes to `common-ui` interfaces beyond additive fixes — ✅ PASS

`packages/common-ui` is **completely untouched** by this PR (diff is confined to `packages/app-web` + the lockfile). `AdwDebuggerView` implements `DebuggerView` as-is; the five widget interfaces (`DebugInfoWidget`, `HexMonitorWidget`, `HexdumpWidget`, `DisassembledWidget`, `MessageConsoleWidget`) all mapped onto Custom Elements without a single signature change. Zero additive fixes were even needed.

### Criterion (b): web view not materially larger/more contorted than its NS twin — ✅ PASS (web is comparable, arguably smaller on like-for-like surface)

| Implementation | View | Widgets | Total |
|---|---:|---:|---:|
| **Web spike (this PR)** | `adw-debugger.ts` 212 | 485 (incl. `index` 8, `styles` 76, `code-card` 31) | **697** |
| Android (NS) twin | `debugger.ts` 231 | 400 (incl. `index` 5) | **631** |
| GNOME (GTK) twin | `debugger.ts` 318 + `.blp` 132 | 830 (`.ts` + `.blp`) | **1280** |

The web view class (212) is **smaller** than its NS view (231). The 66-line total gap over NS is fully accounted for by two web-only helpers that the other platforms get for free from their toolkit:

- `styles.ts` (76 lines) — the NS twin styles via Tailwind classes on native Adwaita widgets; GTK styles via `.blp` + libadwaita CSS. The web needs a little CSS for the code blocks / flag grid / copy-button chrome.
- `code-card.ts` (31 lines) — the NS twin uses a native tap-to-copy gesture on `TextView`; GTK uses `GtkSourceView`'s built-in copy. The web factors the "copy button floating over a `<pre>`" idiom into one helper.

Subtracting those two toolkit substitutes, the web debugger is **~590 lines vs NS 631** — the shapes are near-identical (same widget breakdown, same `section()` helper, same `init(...)` call, same event wiring). Not contorted.

### Criterion (c): service → controller → view flow works without a re-implemented controller — ✅ PASS

The demo page wires the view through the **shared** `GameConsoleEventBridge` (the same class GNOME's `MainWindow` and Android's main view use) with only platform-specific callbacks (English `formatMessage` logging, toast display, clipboard). No controller logic is re-implemented in `app-web`: button clicks call `gameConsoleController.assemble/run/step/stop/reset`; `debuggerController` owns all state.

Verified end-to-end in headless Chrome against the built `dist-spike` bundle:

- **Assemble** → messages log ("Found 1 label", "Code assembled successfully, 11 bytes"), hexdump `0600: a2 00 a5 fe 9d 00 02 e8 d0 f8 00`, disassembly table, "assembled-successfully" toast.
- **Region select → Run → Stop** → hex monitor shows live non-zero `$0200` display bytes; register suffixes update ($hex over dim decimal); state label reaches `completed`.
- **Stepping mode switch** → `active` attribute flips; **Step** advances registers; message log grows.
- **Copy** on the Disassembled card → `copyToEditor` event round-trips into the editor textarea.

Rendering verified in both light and dark schemes (screenshots below): boxed-list settings, register rows, N V - B D I Z C flag grid, region combo, cards, and toasts all render as native Adwaita.

## adwaita-web gaps discovered (feed gjsify ADR 0004 / an adwaita-web fix)

None were blockers — each has a documented local workaround in this PR — but all three should be fixed gjsify-side:

1. **`@gjsify/adwaita-web` type entry points at incomplete source.** Its `exports["."].types` (and `main`/`types`) resolve to `src/index.ts`, but the published tarball's `src/` omits `styles.generated.ts` (only `styles.generated.js` ships). Type-checking a consumer against the src entry fails with `TS7016` (`Could not find a declaration file for module './styles.generated.js'`). The package **does** ship complete built declarations at `lib/types/index.d.ts`. *Workaround here:* a `tsconfig.json` `paths` remap of `@gjsify/adwaita-web` → `./node_modules/@gjsify/adwaita-web/lib/types/index.d.ts`. *Fix:* point the package `types`/`exports.types` at `lib/types/index.d.ts`, or include `styles.generated.ts` (+ `.d.ts`) in the published `src`.

2. **`@gjsify/adwaita-fonts` declares a `types` file it doesn't ship.** Its `exports["."].types` is `./index.d.ts`, but the package is CSS-only (fontsource pattern) and ships no such file. The side-effect `import '@gjsify/adwaita-fonts'` inside adwaita-web's declarations then fails with `TS2882`. *Workaround here:* an ambient `declare module "@gjsify/adwaita-fonts"` in `src/types/adwaita-fonts.d.ts`. *Fix:* ship a trivial `index.d.ts` (or drop the `types` condition for a CSS-only package).

3. **The skin needs a root surface to theme against.** The adwaita-web stylesheet themes via CSS variables (auto light/dark through `prefers-color-scheme`), but expects the window container (normally `<adw-window>`) to paint the root `--window-bg-color`/`--window-fg-color`. A page with no `<adw-window>` chrome renders **white-on-white** until `body` is bound to those tokens. *Workaround here:* a few lines in `debugger-spike.html` binding `body` to `--window-bg-color`/`--window-fg-color` + `color-scheme: light dark`. *Fix (DX):* either an `<adw-application>`/root element that applies the window surface to `:root`/`body`, or a documented "bind body to these tokens if you don't use `<adw-window>`" note.

Minor, non-blocking: there is no standalone monospace/line-numbered source element (GTK uses `GtkSourceView`); a plain `<pre>` was sufficient here.

## Recommendation

**Adopt the per-view migration path** from ADR-0007's decision point. The spike met every criterion: the controller/view layer is genuinely platform-neutral — Custom Elements are a widget tree of the same shape GTK and NativeScript implement, and the shared `GameConsoleEventBridge`/`debuggerController` drove the web view unchanged. Suggested next views: `MainView`, `EditorView`, `GameConsoleView`, migrating `app-web` view-by-view to `common-ui` + `@gjsify/adwaita-web` in follow-up PRs (no big-bang), with the three adwaita-web packaging/DX fixes landed gjsify-side first so consumers don't need the tsconfig workarounds.

Do not merge — spike for review/decision.
