### PR TITLE
Web: learn-package HTML render target

### DIFF
--- a/packages/learn/tsx/components/html/html-box.component.tsx
+++ b/packages/learn/tsx/components/html/html-box.component.tsx
@@ -1,0 +1,45 @@
+import { HtmlWidget } from "./html-widget.compontent.tsx";
+import { HtmlOrientable } from "./html-orientable.compontent.tsx";
+import { Orientation } from "../../enums/gtk.enums.ts";
+
+/**
+ * HtmlBox mirrors GtkBox: a generic flex container used to lay out a group
+ * of children. Renders a plain `<div>` carrying an `adw-box` class plus an
+ * orientation modifier, so app-web's stylesheet can lay the children out
+ * exactly the way the native GtkBox does (flex row/column).
+ */
+export class HtmlBox extends HtmlWidget implements HtmlOrientable {
+  static propertyNames = [...HtmlWidget.propertyNames, ...HtmlOrientable.propertyNames];
+
+  static reservedPropertyNames = [...HtmlWidget.reservedPropertyNames];
+
+  static defaultProps = {
+    ...HtmlWidget.defaultProps,
+    ...HtmlOrientable.defaultProps,
+  };
+
+  constructor(props: any) {
+    super(props);
+    this.setDefaultProps();
+  }
+
+  public render() {
+    const orientation = this.props.orientation ?? Orientation.VERTICAL;
+    const classes = [
+      "adw-box",
+      orientation === Orientation.HORIZONTAL ? "adw-box--horizontal" : "adw-box--vertical",
+      this.props.class,
+    ]
+      .filter(Boolean)
+      .join(" ");
+
+    return <div class={classes}>{this.props.children}</div>;
+  }
+
+  protected setDefaultProps(): void {
+    this.props = {
+      ...HtmlBox.defaultProps,
+      ...this.props,
+    };
+  }
+}

--- a/packages/learn/tsx/components/html/html-code.compontent.tsx
+++ b/packages/learn/tsx/components/html/html-code.compontent.tsx
@@ -1,0 +1,279 @@
+import { renderSSR } from "nano-jsx/esm/index.js";
+import { HtmlWidget } from "./html-widget.compontent.tsx";
+import { CodeType } from "../../enums/gtk.enums.ts";
+import * as Examples from "@learn6502/examples";
+
+const EXAMPLE_NAMES = Object.keys(Examples);
+
+interface HtmlCodeProps {
+  /**
+   * The example to display, if not provided, the children will be used.
+   */
+  example?: keyof typeof Examples;
+  /**
+   * The code to display.
+   */
+  children?: string;
+  /**
+   * Inline or block code.
+   */
+  type: CodeType;
+  /**
+   * The code to display.
+   */
+  code?: string;
+  /**
+   * The class name to use for the code.
+   * @example language-6502-assembler:readonly
+   */
+  className?: string;
+  /**
+   * Whether the code is readonly.
+   */
+  readonly?: boolean;
+  /**
+   * Whether the code is copyable.
+   */
+  copyable?: boolean;
+  /**
+   * Whether the code is unselectable.
+   */
+  unselectable?: boolean;
+  /**
+   * The language of the code.
+   */
+  language?: string;
+  /**
+   * The line numbers to display.
+   */
+  lineNumbers?: boolean;
+  /**
+   * Whether to hide the line numbers.
+   */
+  noLineNumbers?: boolean;
+  /**
+   * The starting value for line numbers.
+   */
+  lineNumberStart?: number;
+  /**
+   * A fixed height (in px) for the block editor, e.g. the tall snake-game
+   * listing. Unset lets the editor size to its content (the CodeMirror
+   * default).
+   */
+  height?: number;
+  /**
+   * A fixed width (in px) for the block editor.
+   */
+  width?: number;
+}
+
+/**
+ * HtmlCode mirrors GtkCode: it renders MDX `code`, distinguishing inline
+ * code from a fenced code block via `type` (set to BLOCK by HtmlPre when the
+ * code is the sole child of a `pre`).
+ *
+ * Block code renders `<adw-source-view>` — the `@gjsify/adwaita-web/source-view`
+ * custom element, the web twin of the GTK target's `SourceView` widget (see
+ * `gtk-code.compontent.tsx`). The learn package itself does not depend on
+ * `@gjsify/adwaita-web`: this only emits the tag + declarative attributes as
+ * markup, the consuming app registers the custom element and CodeMirror
+ * upgrades it client-side (progressive enhancement — the raw text is still
+ * real, crawlable HTML if JS never runs).
+ */
+export class HtmlCode extends HtmlWidget<HtmlCodeProps> {
+  static propertyNames = [...HtmlWidget.propertyNames];
+
+  static reservedPropertyNames = [...HtmlWidget.reservedPropertyNames, "type", "example"];
+
+  static defaultProps = {
+    ...HtmlWidget.defaultProps,
+    type: CodeType.INLINE,
+  };
+
+  private static _codeBlockCounter = 0;
+
+  constructor(props: HtmlCodeProps) {
+    super(props);
+    this.setDefaultProps();
+  }
+
+  render() {
+    let { language, readonly, copyable, unselectable, code, lineNumbers, lineNumberStart, height, width } =
+      this.parseAttributes(this.props);
+
+    code = renderSSR(code);
+    if (code.endsWith("\n")) {
+      code = code.slice(0, -1);
+    }
+
+    // Use the Adwaita-web source-view custom element for block code.
+    if (this.props.type === CodeType.BLOCK) {
+      const id = `sourceView${HtmlCode._codeBlockCounter++}`;
+      const isHex = language === "hex";
+      const style = height || width ? this.toStyle({ height, width }) : undefined;
+
+      return (
+        <adw-source-view
+          id={id}
+          code={code}
+          language={language || undefined}
+          readonly={readonly || undefined}
+          copyable={copyable || undefined}
+          selectable={unselectable ? "false" : undefined}
+          line-numbers={lineNumbers || undefined}
+          line-number-start={lineNumberStart}
+          hex-addresses={isHex || undefined}
+          style={style}
+        />
+      );
+    }
+    // Inline code
+    return <code>{code}</code>;
+  }
+
+  /**
+   * Parse the attributes.
+   * Attributes can be normal attributes or class attributes.
+   * Class attributes have the form `class="language-<language>:<modifier>,..."`
+   * and are used to specify the language and other modifiers for the code.
+   * @param props The props of the code component.
+   * @returns The parsed attributes.
+   */
+  protected parseAttributes(props: HtmlCodeProps): Partial<HtmlCodeProps> {
+    let language = props.language || "";
+    // MDX code blocks are documentation, so they always render read-only;
+    // the only editable source view is the app's own editor.
+    let readonly = props.readonly ?? true;
+    let copyable = props.copyable || false;
+    let unselectable = props.unselectable || false;
+    let noLineNumbers = props.noLineNumbers || false;
+    let lineNumbers = props.lineNumbers || !noLineNumbers;
+    let height = props.height;
+    let width = props.width;
+    let lineNumberStart = props.lineNumberStart !== undefined ? props.lineNumberStart : language === "hex" ? 0 : 1;
+    // E.g. language-6502-assembler:readonly
+    const separator = ":";
+    const languagePrefix = "language-";
+    const examplePrefix = "example-";
+    let code = props.children;
+
+    if (!props.className || !props.className.startsWith(languagePrefix)) {
+      return {
+        language,
+        readonly,
+        copyable,
+        unselectable,
+        lineNumbers,
+        noLineNumbers,
+        code,
+        height,
+        width,
+        lineNumberStart,
+      };
+    }
+    const [langString, ...modifiers] = props.className.split(separator);
+
+    if (langString.startsWith(languagePrefix)) {
+      language = langString.slice(languagePrefix.length);
+      // Re-evaluate the hex default now that the language is known.
+      if (props.lineNumberStart === undefined) {
+        lineNumberStart = language === "hex" ? 0 : 1;
+      }
+    }
+
+    if (modifiers.includes("readonly")) {
+      readonly = true;
+    }
+    if (modifiers.includes("copyable")) {
+      copyable = true;
+    }
+    if (modifiers.includes("unselectable")) {
+      unselectable = true;
+    }
+    if (modifiers.includes("no-line-numbers")) {
+      noLineNumbers = true;
+    }
+    if (modifiers.includes("line-numbers")) {
+      lineNumbers = true;
+    }
+    if (noLineNumbers && !modifiers.includes("line-numbers")) {
+      lineNumbers = false;
+    }
+
+    // E.g. height=600
+    const heightModifier = modifiers.find((modifier) => modifier.startsWith("height="));
+    if (heightModifier) {
+      height = parseInt(heightModifier.slice(heightModifier.indexOf("=") + 1));
+    }
+
+    // E.g. width=600
+    const widthModifier = modifiers.find((modifier) => modifier.startsWith("width="));
+    if (widthModifier) {
+      width = parseInt(widthModifier.slice(widthModifier.indexOf("=") + 1));
+    }
+
+    // E.g. example-snake
+    const exampleModifier = modifiers.find((modifier) => modifier.startsWith(examplePrefix));
+    if (exampleModifier) {
+      const exampleName = exampleModifier.slice(examplePrefix.length);
+      if (EXAMPLE_NAMES.includes(exampleName)) {
+        code = Examples[exampleName as keyof typeof Examples].code;
+      } else {
+        console.warn(`[HtmlCode] Unknown example: ${exampleName}`);
+      }
+    }
+
+    // E.g. line-start=0x0600 for 6502's $0600 start address
+    const lineStartModifier = modifiers.find((modifier) => modifier.startsWith("line-start="));
+    if (lineStartModifier) {
+      let startValue: number;
+      const valueString = lineStartModifier.slice(lineStartModifier.indexOf("=") + 1).trim();
+
+      // Check if it's a hex value (0x... or $...)
+      if (valueString.startsWith("0x") || valueString.startsWith("$")) {
+        const hexString = valueString.startsWith("0x") ? valueString.slice(2) : valueString.slice(1);
+        startValue = parseInt(hexString, 16);
+      } else {
+        // Decimal value
+        startValue = parseInt(valueString, 10);
+      }
+
+      if (!isNaN(startValue) && startValue >= 0) {
+        lineNumberStart = startValue;
+      } else {
+        console.warn(`[HtmlCode] Invalid line-start value: ${valueString}`);
+      }
+    }
+
+    return {
+      language,
+      readonly,
+      copyable,
+      unselectable,
+      code,
+      lineNumbers,
+      noLineNumbers,
+      height,
+      width,
+      lineNumberStart,
+    };
+  }
+
+  protected toStyle(dimensions: { height?: number; width?: number }): string {
+    const parts: string[] = [];
+    if (dimensions.height) {
+      parts.push(`height:${dimensions.height}px`);
+    }
+    if (dimensions.width) {
+      parts.push(`width:${dimensions.width}px`);
+    }
+    return parts.join(";");
+  }
+
+  protected setDefaultProps(): void {
+    this.props = {
+      ...HtmlCode.defaultProps,
+      ...this.props,
+    };
+  }
+}

--- a/packages/learn/tsx/components/html/html-label.component.tsx
+++ b/packages/learn/tsx/components/html/html-label.component.tsx
@@ -1,0 +1,60 @@
+import { HtmlWidget } from "./html-widget.compontent.tsx";
+
+interface HtmlLabelProps {
+  /**
+   * The HTML tag to render. Mirrors how GtkLabel is reused for every
+   * heading level and for paragraphs, distinguished only by an Adwaita
+   * style class — here the distinguishing factor is the concrete tag plus
+   * the same style class.
+   */
+  tag?: "h1" | "h2" | "h3" | "h4" | "p" | "span";
+  class?: string;
+  children?: any;
+}
+
+/**
+ * HtmlLabel mirrors GtkLabel: the single building block every heading level
+ * and paragraph in `html.components.tsx` renders through.
+ *
+ * Unlike GtkLabel — which must flatten its children into one Pango markup
+ * string set on a `label` property — HtmlLabel keeps the DOM tree intact.
+ * nano-jsx's SSR renderer serializes nested elements (links, `<code>`,
+ * `<em>`, `<strong>`) as real nested markup and HTML-escapes plain text
+ * automatically, so inline formatting and links inside prose survive as
+ * real, crawlable HTML instead of being collapsed into a single string.
+ */
+export class HtmlLabel extends HtmlWidget<HtmlLabelProps> {
+  static defaultProps: Partial<HtmlLabelProps> = {
+    tag: "p",
+  };
+
+  constructor(props: HtmlLabelProps) {
+    super(props);
+    this.setDefaultProps();
+  }
+
+  render() {
+    const { tag, class: className, children } = this.props;
+    switch (tag) {
+      case "h1":
+        return <h1 class={className}>{children}</h1>;
+      case "h2":
+        return <h2 class={className}>{children}</h2>;
+      case "h3":
+        return <h3 class={className}>{children}</h3>;
+      case "h4":
+        return <h4 class={className}>{children}</h4>;
+      case "span":
+        return <span class={className}>{children}</span>;
+      default:
+        return <p class={className}>{children}</p>;
+    }
+  }
+
+  protected setDefaultProps(): void {
+    this.props = {
+      ...HtmlLabel.defaultProps,
+      ...this.props,
+    };
+  }
+}

--- a/packages/learn/tsx/components/html/html-orientable.compontent.tsx
+++ b/packages/learn/tsx/components/html/html-orientable.compontent.tsx
@@ -1,0 +1,17 @@
+import { Orientation } from "../../enums/gtk.enums.ts";
+
+/**
+ * HtmlOrientable mirrors GtkOrientable: a component that lays its children
+ * out either horizontally or vertically. On the web this drives a CSS
+ * modifier class (`adw-box--horizontal`/`adw-box--vertical`) instead of a
+ * GObject `orientation` property, but the contract (the prop name + the
+ * `Orientation` enum it's expressed in) is shared with the GTK target so the
+ * same MDX authoring intent maps identically across render targets.
+ */
+export abstract class HtmlOrientable {
+  static propertyNames = ["orientation"];
+
+  static defaultProps = {
+    orientation: Orientation.VERTICAL,
+  };
+}

--- a/packages/learn/tsx/components/html/html-pre.compontent.tsx
+++ b/packages/learn/tsx/components/html/html-pre.compontent.tsx
@@ -1,0 +1,43 @@
+import { HtmlWidget } from "./html-widget.compontent.tsx";
+import { HtmlCode } from "./html-code.compontent.tsx";
+import { CodeType } from "../../enums/gtk.enums.ts";
+
+/**
+ * HtmlPre mirrors GtkPre/NsPre: MDX renders a fenced code block as
+ * `pre > code`, so `pre` forces its `code` child into BLOCK mode (the
+ * `<adw-source-view>` editor) instead of wrapping it in an extra element —
+ * exactly like the GTK/NS targets avoid double-nesting their own SourceView
+ * widget inside another container.
+ */
+export class HtmlPre extends HtmlWidget {
+  static propertyNames = [...HtmlWidget.propertyNames];
+
+  static reservedPropertyNames = [...HtmlWidget.reservedPropertyNames];
+
+  static defaultProps = {
+    ...HtmlWidget.defaultProps,
+  };
+
+  constructor(props: any) {
+    super(props);
+    this.setDefaultProps();
+  }
+
+  render() {
+    // If the first child is a code component, render it directly as a block
+    // (skip the <pre> wrapper — the source-view element owns its own chrome).
+    if (this.props.children.length > 0 && this.props.children[0].component === HtmlCode) {
+      this.props.children[0].props.type = CodeType.BLOCK;
+      return this.props.children[0];
+    }
+    // Fallback: a plain preformatted text block (no code component detected).
+    return <pre>{this.props.children}</pre>;
+  }
+
+  protected setDefaultProps(): void {
+    this.props = {
+      ...HtmlPre.defaultProps,
+      ...this.props,
+    };
+  }
+}

--- a/packages/learn/tsx/components/html/html-root.component.tsx
+++ b/packages/learn/tsx/components/html/html-root.component.tsx
@@ -1,0 +1,27 @@
+import { Component } from "nano-jsx/esm/index.js";
+import { HtmlBox } from "./html-box.component.tsx";
+import { Orientation } from "../../enums/gtk.enums.ts";
+
+/**
+ * HtmlRoot mirrors GtkRoot/NsRoot: it wraps a whole generated document
+ * (tutorial or quick-help) in a single top-level container carrying the
+ * view name as a CSS class — exactly like GtkRoot's
+ * `<template class={...} parent="MdxView">`.
+ *
+ * Unlike the GTK target, this does not produce a whole window/page — it is
+ * a self-contained HTML fragment (no `<html>`/`<head>`/`<body>`), meant to
+ * be mounted into an existing app-web view (e.g. via `element.replaceChildren
+ * (...)` on a container, or served as prerendered markup the client
+ * hydrates in place) — the same "fragment, not a document" shape as the
+ * GTK `.ui` XML being spliced into a larger `MdxView` template.
+ */
+export class HtmlRoot extends Component {
+  render() {
+    const classes = ["learn-view", this.props.class].filter(Boolean).join(" ");
+    return (
+      <HtmlBox class={classes} orientation={Orientation.VERTICAL}>
+        {this.props.children}
+      </HtmlBox>
+    );
+  }
+}

--- a/packages/learn/tsx/components/html/html-text-list.compontent.tsx
+++ b/packages/learn/tsx/components/html/html-text-list.compontent.tsx
@@ -1,0 +1,42 @@
+import { Component } from "nano-jsx/esm/index.js";
+import { TextListType } from "../../enums/gtk.enums.ts";
+
+interface HtmlTextListProps {
+  type?: TextListType;
+  class?: string;
+  children?: any;
+}
+
+/**
+ * HtmlTextList mirrors GtkTextList's role — bridging MDX's `ol`/`ul` into
+ * the target's list primitive — but is far simpler: GTK has no native list
+ * widget and must fabricate numbered rows out of GtkBox + GtkLabel, while
+ * HTML has real `<ol>`/`<ul>` elements. This is just a thin wrapper that
+ * picks the right tag and adds an Adwaita-friendly class for styling; the
+ * `li` mapping in `html.components.tsx` renders the actual `<li>` items.
+ */
+export class HtmlTextList extends Component<HtmlTextListProps> {
+  static defaultProps: Partial<HtmlTextListProps> = {
+    type: TextListType.ORDERED,
+  };
+
+  constructor(props: HtmlTextListProps) {
+    super(props);
+    this.setDefaultProps();
+  }
+
+  render() {
+    const classes = ["adw-list", this.props.class].filter(Boolean).join(" ");
+    if (this.props.type === TextListType.ORDERED) {
+      return <ol class={classes}>{this.props.children}</ol>;
+    }
+    return <ul class={classes}>{this.props.children}</ul>;
+  }
+
+  protected setDefaultProps(): void {
+    this.props = {
+      ...HtmlTextList.defaultProps,
+      ...this.props,
+    };
+  }
+}

--- a/packages/learn/tsx/components/html/html-widget.compontent.tsx
+++ b/packages/learn/tsx/components/html/html-widget.compontent.tsx
@@ -1,0 +1,39 @@
+import { Component } from "nano-jsx/esm/index.js";
+
+/**
+ * Base class for the HTML target's component set.
+ *
+ * Mirrors GtkWidget's role (the common base every leaf/container component
+ * extends) but adapted to HTML: GTK needs a strict property allow-list
+ * because every value round-trips through a `<property name="...">` GObject
+ * XML element, while an HTML attribute is valid for (almost) any name
+ * (`data-*`, `aria-*`, ...). So instead of validating props, this base just
+ * documents the small set of global attributes the HTML components care
+ * about and provides the same default-props plumbing as its GTK/NS twins.
+ */
+export class HtmlWidget<P extends object = any, S = any> extends Component<P, S> {
+  static propertyNames = ["id", "class", "style", "title", "hidden", "tabindex", "lang", "dir", "role"];
+
+  static reservedPropertyNames = ["children"];
+
+  static defaultProps = {
+    // TODO: Implement default props
+  };
+
+  constructor(props: P) {
+    super(props);
+    this.setDefaultProps();
+  }
+
+  public render() {
+    const props = this.props as any;
+    return <div class={props.class}>{props.children}</div>;
+  }
+
+  protected setDefaultProps(): void {
+    this.props = {
+      ...HtmlWidget.defaultProps,
+      ...this.props,
+    };
+  }
+}

--- a/packages/learn/tsx/components/html/html.components.tsx
+++ b/packages/learn/tsx/components/html/html.components.tsx
@@ -1,0 +1,63 @@
+import type { MDXComponents } from "mdx/types";
+
+import { HtmlLabel } from "./html-label.component.tsx";
+import { HtmlRoot } from "./html-root.component.tsx";
+import { HtmlPre } from "./html-pre.compontent.tsx";
+import { HtmlTextList } from "./html-text-list.compontent.tsx";
+import { HtmlCode } from "./html-code.compontent.tsx";
+import { TextListType } from "../../enums/gtk.enums.ts";
+
+/**
+ * MDX -> HTML component map. Mirrors GtkComponents' shape and coverage
+ * (same element set: headings, paragraphs, code, lists, sub/sup, em/strong)
+ * but leaves plain-passthrough elements (`a`, `img`, `table`/`tr`/`td`/`th`)
+ * unmapped — MDX already renders those as real, semantic HTML by default,
+ * which is exactly what we want here (unlike the GTK target, which has no
+ * native anchor/table widget and must fold or drop them).
+ */
+export const HtmlComponents: MDXComponents = {
+  HtmlRoot,
+  HtmlLabel,
+  h1: (props: any) => (
+    <HtmlLabel {...props} tag="h1" class="title-1">
+      {props.children}
+    </HtmlLabel>
+  ),
+  h2: (props: any) => (
+    <HtmlLabel {...props} tag="h2" class="title-2">
+      {props.children}
+    </HtmlLabel>
+  ),
+  h3: (props: any) => (
+    <HtmlLabel {...props} tag="h3" class="title-3">
+      {props.children}
+    </HtmlLabel>
+  ),
+  h4: (props: any) => (
+    <HtmlLabel {...props} tag="h4" class="title-4">
+      {props.children}
+    </HtmlLabel>
+  ),
+  p: (props: any) => (
+    <HtmlLabel {...props} tag="p" class="body">
+      {props.children}
+    </HtmlLabel>
+  ),
+  pre: HtmlPre,
+  code: HtmlCode,
+  ol: (props: any) => (
+    <HtmlTextList {...props} type={TextListType.ORDERED}>
+      {props.children}
+    </HtmlTextList>
+  ),
+  ul: (props: any) => (
+    <HtmlTextList {...props} type={TextListType.UNORDERED}>
+      {props.children}
+    </HtmlTextList>
+  ),
+  li: (props: any) => <li>{props.children}</li>,
+  sub: (props: any) => <sub {...props}>{props.children}</sub>,
+  sup: (props: any) => <sup {...props}>{props.children}</sup>,
+  em: (props: any) => <em {...props}>{props.children}</em>,
+  strong: (props: any) => <strong {...props}>{props.children}</strong>,
+};

--- a/packages/learn/tsx/components/html/index.tsx
+++ b/packages/learn/tsx/components/html/index.tsx
@@ -1,1 +1,9 @@
-export {};
+export { HtmlBox } from "./html-box.component.tsx";
+export { HtmlLabel } from "./html-label.component.tsx";
+export { HtmlTextList } from "./html-text-list.compontent.tsx";
+export { HtmlOrientable } from "./html-orientable.compontent.tsx";
+export { HtmlPre } from "./html-pre.compontent.tsx";
+export { HtmlRoot } from "./html-root.component.tsx";
+export { HtmlWidget } from "./html-widget.compontent.tsx";
+export { HtmlCode } from "./html-code.compontent.tsx";
+export { HtmlComponents } from "./html.components.tsx";

--- a/packages/learn/tsx/index.tsx
+++ b/packages/learn/tsx/index.tsx
@@ -2,7 +2,7 @@ import { renderSSR } from "nano-jsx/esm/index.js";
 import Tutorial from "../tutorial.mdx";
 import QuickHelp from "../quick-help.mdx";
 import { GtkComponents, GtkRoot } from "./components/gtk/index.tsx";
-// import * as HtmlComponents from './components/html/index.tsx'
+import { HtmlComponents, HtmlRoot } from "./components/html/index.tsx";
 import { components as NsComponents, generateNativeScriptXml, NsRoot } from "./components/nativescript/index.tsx";
 import { writeFile } from "node:fs/promises";
 import { withSourceFileContext } from "./utils.ts";
@@ -74,5 +74,23 @@ const quickHelpXml = generateNativeScriptXml(
 await saveNativeScriptXml("quick-help", quickHelpXml);
 
 // Generate HTML files
-await generateHtml("tutorial", renderSSR(<Tutorial />));
-await generateHtml("quick-help", renderSSR(<QuickHelp />));
+await generateHtml(
+  "tutorial",
+  withSourceFileContext("packages/learn/tutorial.mdx", () =>
+    renderSSR(
+      <HtmlRoot class="TutorialView">
+        <Tutorial components={HtmlComponents} />
+      </HtmlRoot>
+    )
+  )
+);
+await generateHtml(
+  "quick-help",
+  withSourceFileContext("packages/learn/quick-help.mdx", () =>
+    renderSSR(
+      <HtmlRoot class="QuickHelpView">
+        <QuickHelp components={HtmlComponents} />
+      </HtmlRoot>
+    )
+  )
+);


### PR DESCRIPTION
## Summary

Implements the **HTML/web render target** for `@learn6502/learn` — the next phase of the app-web Adwaita rewrite (Phase 1, the SPA shell, landed in #159). The shared 6502 tutorial + quick-help MDX (authored once) now renders to a third target — semantic, `@gjsify/adwaita-web`-friendly HTML — alongside the existing GTK `.ui` XML and NativeScript XML targets. `html/index.tsx` was previously an empty `export {}` stub.

## Component contract (mirrors the GTK set 1:1)

| HTML component | GTK twin | Responsibility |
|---|---|---|
| `HtmlWidget` (base) | `GtkWidget` | common base + default-props plumbing |
| `HtmlOrientable` (mixin) | `GtkOrientable` | horizontal/vertical via `Orientation` enum |
| `HtmlBox` | `GtkBox` | flex container (`adw-box` + orientation modifier) |
| `HtmlLabel` | `GtkLabel` | headings/paragraphs (keeps nested inline markup + links intact) |
| `HtmlCode` | `GtkCode` | inline `<code>` / block `<adw-source-view>`; same `language-*:modifier` class parsing (readonly, copyable, unselectable, line-numbers, `example-*`, `height=`, `line-start=0x…`) |
| `HtmlPre` | `GtkPre` | forces a `code` child into BLOCK mode |
| `HtmlTextList` | `GtkTextList` | `ol`/`ul` (`adw-list`) |
| `HtmlRoot` | `GtkRoot` | view-name wrapper fragment |
| `HtmlComponents` | `GtkComponents` | MDX element map (h1–h4, p, pre, code, ol/ul/li, sub/sup, em/strong) |

`tsx/index.tsx` now renders `HtmlRoot` + `HtmlComponents` for both documents (previously a bare `<Tutorial />` with no component map).

### Interactive code blocks → `<adw-source-view>`

Fenced code blocks emit `<adw-source-view>` — the `@gjsify/adwaita-web/source-view` custom element, the web twin of the GTK target's `SourceView` widget — with the same declarative attributes the native widget takes (`code`, `language`, `readonly`, `copyable`, `selectable`, `line-numbers`, `line-number-start`, `hex-addresses`). The learn package does **not** depend on `@gjsify/adwaita-web`: it only emits the tag + attributes as markup; the consuming app registers the element so CodeMirror upgrades it client-side (progressive enhancement — the raw code stays real, crawlable HTML if JS never runs).

## Verification

- `gjsify tsc --noEmit`: 17 pre-existing baseline errors, **0 new** (verified by stashing the change — count is identical with/without). No errors in `html/*`.
- `oxlint`: only `no-explicit-any` warnings (19), consistent with the GTK set (23) — the MDX component contract passes untyped `props`.
- `gjsify format --check`: clean.
- Built (`build:mdx`) + generated (`build:js`) successfully; output re-verified byte-identical after formatting.

Representative generated section (heading + prose + interactive code block):

```html
<h2 class="title-2">Our first program</h2>
<p class="body">So, let&apos;s dive in! This application contains a <a href="https://github.com/JumpLink/Learn6502/tree/main/packages/core">JavaScript 6502 Assembler and Simulator</a> that I have adapted for this interactive tutorial.
Click the <strong>Copy</strong> button in the code block below to copy the example code to the editor. ...</p>
<adw-source-view id="sourceView0" code="LDA #$01
STA $0200
..." language="6502-assembler" readonly="true" copyable="true" line-numbers="true" line-number-start="1"></adw-source-view>
```

Hex blocks → `hex-addresses="true"` + `line-number-start` from `line-start=0x…`; the snake example → `style="height:600px"`; `unselectable` → `selectable="false"`; `ol`/`ul` → real `<ol class="adw-list">`/`<li>`.

## Open questions

1. **Interactive `<Widget>` embeds.** The current MDX has **no** explicit `<Widget>` JSX embeds — the interactive surface is the copyable/hex code blocks, which map to `<adw-source-view>`. The classic Jekyll site had a full inline simulator widget (`_includes/widget.html`: buttons + canvas + debugger). Whether the web tutorial should embed that richer simulator inline (vs. the app's shared editor/console) is a product/wiring decision for a later phase.
2. **app-web consumption.** This produces standalone HTML *fragments* (no `<html>`/`<head>`/`<body>`), the same "fragment, not document" shape as the GTK `.ui` spliced into `MdxView`. Wiring app-web's Learn view to fetch/mount this fragment (and register `@gjsify/adwaita-web/source-view` so the code blocks upgrade) is the intended follow-up phase — not done here, per scope (app-web untouched).

https://claude.ai/code/session_01M447HZHo6YgQem4K3TXq9r