### PR TITLE
Web: app-web styles as .css + app.html entry (0.16.3)

### DIFF
--- a/gjsify-lock.json
+++ b/gjsify-lock.json
@@ -43,9 +43,9 @@
     "@gjsify/storybook@^0.10.0",
     "@gjsify/vite-plugin-blueprint@^0.10.0",
     "@gjsify/vite-plugin-gettext@^0.10.0",
-    "@gjsify/adwaita-web@^0.16.1",
-    "@gjsify/cli@^0.16.1",
-    "@gjsify/vite-plugin-gjsify@^0.16.1",
+    "@gjsify/adwaita-web@^0.16.3",
+    "@gjsify/cli@^0.16.3",
+    "@gjsify/vite-plugin-gjsify@^0.16.3",
     "lightningcss@^1.32.0",
     "@types/node@^25.9.1",
     "@gjsify/dom-elements@^0.10.0",
@@ -1614,28 +1614,28 @@
       }
     },
     "node_modules/@gjsify/adwaita-web": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/adwaita-web/-/adwaita-web-0.16.1.tgz",
-      "integrity": "sha512-pIJNhzLCCcU0lM4HLU6f4hZNHlsoSWogAAZGaGQotvjW74eBrmGkvzNL2CP4E0kFGf19n1eEkDA5nHBGH0O6BQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/adwaita-web/-/adwaita-web-0.16.3.tgz",
+      "integrity": "sha512-teUN7N2VpR6+jPqGeiTPZ2rjGqZ/p+AZqPVLAtw+dmbqhy58EdylY1HT+apVgNu2fVHQYawRDxrLje38xW8meQ==",
       "dependencies": {
         "@codemirror/commands": "^6.10.4",
         "@codemirror/language": "^6.12.4",
         "@codemirror/state": "^6.7.0",
         "@codemirror/view": "^6.43.4",
-        "@gjsify/adwaita-fonts": "^0.16.1",
-        "@gjsify/adwaita-icons": "^0.16.1",
+        "@gjsify/adwaita-fonts": "^0.16.3",
+        "@gjsify/adwaita-icons": "^0.16.3",
         "@lezer/highlight": "^1.2.3"
       }
     },
     "node_modules/@gjsify/adwaita-web/node_modules/@gjsify/adwaita-fonts": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/adwaita-fonts/-/adwaita-fonts-0.16.1.tgz",
-      "integrity": "sha512-3gzh4vSKMWePDyU0MD312JypmzwxlxqJCAslz4FGfH8vpHmfDeJc6FpimiiMIjca4MyBmG2P5CvvIW4ZmbKx8Q=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/adwaita-fonts/-/adwaita-fonts-0.16.3.tgz",
+      "integrity": "sha512-fQ+/J3+hKkSTEMZDVCFtYDKlNQGZX6OPAELJ51oyb2GZsaBm78HPskp/lbZtIFGk4Pql+V4wHOEwQwNrxIqQrw=="
     },
     "node_modules/@gjsify/adwaita-web/node_modules/@gjsify/adwaita-icons": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/adwaita-icons/-/adwaita-icons-0.16.1.tgz",
-      "integrity": "sha512-BbtXodO2Cv4tGIjSrgV3HzBdCRtIYrrjTEIfHPqflXaL6c3WkI6Km4XofdTF8T+2UFmZuczQGTbAt2/KANo9Zw=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/adwaita-icons/-/adwaita-icons-0.16.3.tgz",
+      "integrity": "sha512-I90k5wluBTe7mTO9cYNnzgkEc1eBqtFd2lXygt/5eKn0EPh7ujTaD/cjxWJ9s0+qNCViY6TfYUbSQM50QUSkvA=="
     },
     "node_modules/@gjsify/assert": {
       "version": "0.10.0",
@@ -1685,23 +1685,23 @@
       }
     },
     "node_modules/@gjsify/cli": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/cli/-/cli-0.16.1.tgz",
-      "integrity": "sha512-20erPUMnnFLzbFuNMyCkvMTr2Vjkm/GCbPYBNZUTMAedznNWnK3SeP5brKT35FW8GZWYgNrSmkANU015VuFoRQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/cli/-/cli-0.16.3.tgz",
+      "integrity": "sha512-2TzXVwKxJ/F46euuhiR7gaXYJZ2l3y/iszn9Hrwm5ja3MFwl2GQRdY+f8V7BQwR57Vlk9AubIcrQUICVb+kkkA==",
       "dependencies": {
-        "@gjsify/buffer": "^0.16.1",
-        "@gjsify/create-app": "^0.16.1",
-        "@gjsify/node-globals": "^0.16.1",
-        "@gjsify/node-polyfills": "^0.16.1",
-        "@gjsify/npm-registry": "^0.16.1",
-        "@gjsify/resolve-npm": "^0.16.1",
-        "@gjsify/rolldown-plugin-gjsify": "^0.16.1",
-        "@gjsify/rolldown-plugin-pnp": "^0.16.1",
-        "@gjsify/semver": "^0.16.1",
-        "@gjsify/tar": "^0.16.1",
-        "@gjsify/tsc": "^0.16.1",
-        "@gjsify/web-polyfills": "^0.16.1",
-        "@gjsify/workspace": "^0.16.1",
+        "@gjsify/buffer": "^0.16.3",
+        "@gjsify/create-app": "^0.16.3",
+        "@gjsify/node-globals": "^0.16.3",
+        "@gjsify/node-polyfills": "^0.16.3",
+        "@gjsify/npm-registry": "^0.16.3",
+        "@gjsify/resolve-npm": "^0.16.3",
+        "@gjsify/rolldown-plugin-gjsify": "^0.16.3",
+        "@gjsify/rolldown-plugin-pnp": "^0.16.3",
+        "@gjsify/semver": "^0.16.3",
+        "@gjsify/tar": "^0.16.3",
+        "@gjsify/tsc": "^0.16.3",
+        "@gjsify/web-polyfills": "^0.16.3",
+        "@gjsify/workspace": "^0.16.3",
         "cosmiconfig": "^9.0.2",
         "get-tsconfig": "^4.14.0",
         "pkg-types": "^2.3.1",
@@ -1713,17 +1713,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/buffer": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.1.tgz",
-      "integrity": "sha512-dgapws5yErcmSb2EzKau/HOx7+oRmWnq25RIBv8ujmoq42hInIy1lrkpS0zqJtktqJEVO0yZi3JVedVkH/pzlw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.3.tgz",
+      "integrity": "sha512-dGzEBnIvm98W2Je8nWBH2k4ctHUerqZ8ABLr6QJ3JZHUaoYdQASQwVxsfzzxfkFu5/i/IEL/cNZVEKGet8sfeg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/buffer/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -1841,24 +1841,24 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/create-app": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/create-app/-/create-app-0.16.1.tgz",
-      "integrity": "sha512-hdy20a7/kpnz4NMDPmVT6hNu5x2J0m258fGqvuMteekpAczV9QR1mkx9CrINKVFWSbMCNUVD5L9itzK2JiqVgA==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/create-app/-/create-app-0.16.3.tgz",
+      "integrity": "sha512-CMHQIgyRdaSnTAo7zvz6iK3TlCUlMaB0by1ikpxDHFUwQHhT5HmwV6fWZDZqOnM6X4miCqGgchHOyI4LuOaKIQ==",
       "dependencies": {
         "yargs": "^18.0.0"
       },
       "bin": "./lib/index.js"
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-globals": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/node-globals/-/node-globals-0.16.1.tgz",
-      "integrity": "sha512-cRmaWCOpJvXktli/j5LfH9MG3xyc2KsbjfHQplyKWc4T2Z+QuDZ/9fJRQa08W8r3JvQ1Lb+0MY97QakzrytDHA==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/node-globals/-/node-globals-0.16.3.tgz",
+      "integrity": "sha512-nTGUjCWgWlALor0j24A6YLXQeW1Q61Z3vlGQ+BT8Xf4G8n6ODJk56SRiP26cT0TYIiMwbVuW5CERFDW2AMC7tQ==",
       "dependencies": {
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/buffer": "^0.16.1",
-        "@gjsify/process": "^0.16.1",
-        "@gjsify/url": "^0.16.1",
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/buffer": "^0.16.3",
+        "@gjsify/process": "^0.16.3",
+        "@gjsify/url": "^0.16.3",
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-globals/node_modules/@girs/glib-2.0": {
@@ -1922,17 +1922,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-globals/node_modules/@gjsify/buffer": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.1.tgz",
-      "integrity": "sha512-dgapws5yErcmSb2EzKau/HOx7+oRmWnq25RIBv8ujmoq42hInIy1lrkpS0zqJtktqJEVO0yZi3JVedVkH/pzlw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.3.tgz",
+      "integrity": "sha512-dGzEBnIvm98W2Je8nWBH2k4ctHUerqZ8ABLr6QJ3JZHUaoYdQASQwVxsfzzxfkFu5/i/IEL/cNZVEKGet8sfeg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-globals/node_modules/@gjsify/buffer/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -2032,28 +2032,28 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-globals/node_modules/@gjsify/process": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/process/-/process-0.16.1.tgz",
-      "integrity": "sha512-XdaRFYRwrhltnw+rLjysdTDhC9HTNFwEpplIdCle1ROhe3/rqFpyUpKWnZ7vrgsbDTk66u0mLEZkper0LFdqYA==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/process/-/process-0.16.3.tgz",
+      "integrity": "sha512-/kdS5cL2I86Mzf/Mnovkspyf+IvxrGntKtLQGdUynRiL6Lduw8cRHVUHaB+NV0YpMSikY6oUcI8Bu8S8n6Ra6A==",
       "dependencies": {
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/string_decoder": "^0.16.1",
-        "@gjsify/terminal-native": "^0.16.1",
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/string_decoder": "^0.16.3",
+        "@gjsify/terminal-native": "^0.16.3",
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-globals/node_modules/@gjsify/process/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-globals/node_modules/@gjsify/process/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -2153,25 +2153,25 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-globals/node_modules/@gjsify/process/node_modules/@gjsify/string_decoder": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/string_decoder/-/string_decoder-0.16.1.tgz",
-      "integrity": "sha512-CJWri5Z/NSQn5jyav8Sd4EwOzIu5a7WVjo2c1FPWVVzftRAblBeRgI0d/V4/h+0ag3F19SatG9lgA6c205ZyxA==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/string_decoder/-/string_decoder-0.16.3.tgz",
+      "integrity": "sha512-6lnHN/rO7y+CLpiPO6wwBo/yqIuvI4OseAsokH0CecH2CWOU5k0xHwHLPOyFiyJptFd3vX2MvggzNZazx/wikw==",
       "dependencies": {
-        "@gjsify/buffer": "^0.16.1"
+        "@gjsify/buffer": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-globals/node_modules/@gjsify/process/node_modules/@gjsify/string_decoder/node_modules/@gjsify/buffer": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.1.tgz",
-      "integrity": "sha512-dgapws5yErcmSb2EzKau/HOx7+oRmWnq25RIBv8ujmoq42hInIy1lrkpS0zqJtktqJEVO0yZi3JVedVkH/pzlw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.3.tgz",
+      "integrity": "sha512-dGzEBnIvm98W2Je8nWBH2k4ctHUerqZ8ABLr6QJ3JZHUaoYdQASQwVxsfzzxfkFu5/i/IEL/cNZVEKGet8sfeg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-globals/node_modules/@gjsify/process/node_modules/@gjsify/string_decoder/node_modules/@gjsify/buffer/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -2271,9 +2271,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-globals/node_modules/@gjsify/process/node_modules/@gjsify/terminal-native": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native/-/terminal-native-0.16.1.tgz",
-      "integrity": "sha512-0lwVideLC0Kt226+OPjIhXZ/y6Uapn5hj0mmvFrH97LiHxJ9YOIkbaxk410CCfVaHHbpTUXJ/8EyR4Kb+WXlTQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native/-/terminal-native-0.16.3.tgz",
+      "integrity": "sha512-6E0TownC66KhgV/5cKgJ4G/lc7WrSm+FTURa0DiaJKbm8Kf2kpOYo295ZZ/2q0vNwU1+MYjn5hU8EcgsmhuPSw==",
       "dependencies": {
         "@girs/glib-2.0": "^4.1.0",
         "@girs/gobject-2.0": "^4.1.0"
@@ -2331,9 +2331,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-globals/node_modules/@gjsify/process/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -2433,17 +2433,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-globals/node_modules/@gjsify/url": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.16.1.tgz",
-      "integrity": "sha512-+enwAVUFMLMrca9spA2sjHcZJuHLWMSLqG5TuLRbpNcKAhnUxkAK1vERZ10rj8Y9Jo639Y+q0t9vqUxHR+sKmg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.16.3.tgz",
+      "integrity": "sha512-7oNt6TYBQCzKcf/7D8v2nBqw/D+a0rzuQ1J4jITqO/nHYQXGt4oV7RaLa7sC6EHNaoj0l9sUKPP3IMhm2+RNNw==",
       "dependencies": {
         "@girs/glib-2.0": "^4.1.0"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-globals/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -2543,77 +2543,77 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/node-polyfills/-/node-polyfills-0.16.1.tgz",
-      "integrity": "sha512-cgVgJZlWsWq1Ont7kL7eG9YmNg+Farb/Tq/WpmzrQ70pjJYCIf1tCBbmab4ED85M2c8QAzIpR5uLdeEwno9Lww==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/node-polyfills/-/node-polyfills-0.16.3.tgz",
+      "integrity": "sha512-ooGujJVWuv8WyRPE+gwp0udrpqaGjeDpAbiWUcbgQGFoWGeUKt5lpxUBKyt6cvRtO7BeXx35mPyAbOZ9XWj+cg==",
       "dependencies": {
-        "@gjsify/assert": "^0.16.1",
-        "@gjsify/async_hooks": "^0.16.1",
-        "@gjsify/buffer": "^0.16.1",
-        "@gjsify/child_process": "^0.16.1",
-        "@gjsify/cluster": "^0.16.1",
-        "@gjsify/console": "^0.16.1",
-        "@gjsify/constants": "^0.16.1",
-        "@gjsify/crypto": "^0.16.1",
-        "@gjsify/dgram": "^0.16.1",
-        "@gjsify/diagnostics_channel": "^0.16.1",
-        "@gjsify/dns": "^0.16.1",
-        "@gjsify/domain": "^0.16.1",
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/fs": "^0.16.1",
-        "@gjsify/http": "^0.16.1",
-        "@gjsify/http2": "^0.16.1",
-        "@gjsify/https": "^0.16.1",
-        "@gjsify/inspector": "^0.16.1",
-        "@gjsify/module": "^0.16.1",
-        "@gjsify/net": "^0.16.1",
-        "@gjsify/node-globals": "^0.16.1",
-        "@gjsify/os": "^0.16.1",
-        "@gjsify/path": "^0.16.1",
-        "@gjsify/perf_hooks": "^0.16.1",
-        "@gjsify/process": "^0.16.1",
-        "@gjsify/querystring": "^0.16.1",
-        "@gjsify/readline": "^0.16.1",
-        "@gjsify/sqlite": "^0.16.1",
-        "@gjsify/stream": "^0.16.1",
-        "@gjsify/string_decoder": "^0.16.1",
-        "@gjsify/sys": "^0.16.1",
-        "@gjsify/timers": "^0.16.1",
-        "@gjsify/tls": "^0.16.1",
-        "@gjsify/tty": "^0.16.1",
-        "@gjsify/url": "^0.16.1",
-        "@gjsify/util": "^0.16.1",
-        "@gjsify/v8": "^0.16.1",
-        "@gjsify/vm": "^0.16.1",
-        "@gjsify/worker_threads": "^0.16.1",
-        "@gjsify/zlib": "^0.16.1"
+        "@gjsify/assert": "^0.16.3",
+        "@gjsify/async_hooks": "^0.16.3",
+        "@gjsify/buffer": "^0.16.3",
+        "@gjsify/child_process": "^0.16.3",
+        "@gjsify/cluster": "^0.16.3",
+        "@gjsify/console": "^0.16.3",
+        "@gjsify/constants": "^0.16.3",
+        "@gjsify/crypto": "^0.16.3",
+        "@gjsify/dgram": "^0.16.3",
+        "@gjsify/diagnostics_channel": "^0.16.3",
+        "@gjsify/dns": "^0.16.3",
+        "@gjsify/domain": "^0.16.3",
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/fs": "^0.16.3",
+        "@gjsify/http": "^0.16.3",
+        "@gjsify/http2": "^0.16.3",
+        "@gjsify/https": "^0.16.3",
+        "@gjsify/inspector": "^0.16.3",
+        "@gjsify/module": "^0.16.3",
+        "@gjsify/net": "^0.16.3",
+        "@gjsify/node-globals": "^0.16.3",
+        "@gjsify/os": "^0.16.3",
+        "@gjsify/path": "^0.16.3",
+        "@gjsify/perf_hooks": "^0.16.3",
+        "@gjsify/process": "^0.16.3",
+        "@gjsify/querystring": "^0.16.3",
+        "@gjsify/readline": "^0.16.3",
+        "@gjsify/sqlite": "^0.16.3",
+        "@gjsify/stream": "^0.16.3",
+        "@gjsify/string_decoder": "^0.16.3",
+        "@gjsify/sys": "^0.16.3",
+        "@gjsify/timers": "^0.16.3",
+        "@gjsify/tls": "^0.16.3",
+        "@gjsify/tty": "^0.16.3",
+        "@gjsify/url": "^0.16.3",
+        "@gjsify/util": "^0.16.3",
+        "@gjsify/v8": "^0.16.3",
+        "@gjsify/vm": "^0.16.3",
+        "@gjsify/worker_threads": "^0.16.3",
+        "@gjsify/zlib": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/assert": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/assert/-/assert-0.16.1.tgz",
-      "integrity": "sha512-WsO0jlNImRHNLg8cjKVs8DSE/JPI4Buk5R5MXH722wFE7rM5o1LAbtWzM1x6b1C2i5Z8SdlduX7CVh9Tzto3DQ=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/assert/-/assert-0.16.3.tgz",
+      "integrity": "sha512-WWhrxKfyPNEs7fu8u2OklDaZ0ke+wWdS65W5KGejx+k8TyeLwZX4N+xQ8j9jwMpJCDuGjrCcT/yQeHHHkVi1Gg=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/async_hooks": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/async_hooks/-/async_hooks-0.16.1.tgz",
-      "integrity": "sha512-HUXh/dxcd7d6JmoWpu5aQOIjvS5f3AJ02Rcv1J6nR7Lu54fkeHjANgQDVDdly14brmHWytz3Vfdlg2WkXR1Iaw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/async_hooks/-/async_hooks-0.16.3.tgz",
+      "integrity": "sha512-u57x/+pHKJkBU3X6KK4QR7CjHPu4DEKN095ThdBZoCdJWPfz3d5qnPmPE4DURhbe1TenEjIEKnsXGcfOG9Tr/g==",
       "dependencies": {
-        "@gjsify/events": "^0.16.1"
+        "@gjsify/events": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/async_hooks/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/async_hooks/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -2731,17 +2731,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/buffer": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.1.tgz",
-      "integrity": "sha512-dgapws5yErcmSb2EzKau/HOx7+oRmWnq25RIBv8ujmoq42hInIy1lrkpS0zqJtktqJEVO0yZi3JVedVkH/pzlw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.3.tgz",
+      "integrity": "sha512-dGzEBnIvm98W2Je8nWBH2k4ctHUerqZ8ABLr6QJ3JZHUaoYdQASQwVxsfzzxfkFu5/i/IEL/cNZVEKGet8sfeg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/buffer/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -2859,15 +2859,15 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/child_process": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/child_process/-/child_process-0.16.1.tgz",
-      "integrity": "sha512-9fqmNyLwOMJVleGSsW5ay++ftWWsy2acfIBRFvF8sVO/Udhw03ZVFUNzn3KgHUJl+m8047Br08ZbTxobKib4tg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/child_process/-/child_process-0.16.3.tgz",
+      "integrity": "sha512-Wvzra4U9Bi+tzW/WROC7QjR5UCJCoK8qUgp6IulIDuk/KZz9k5Lj+LKdN7yRjtzkHYKPPLw/Iy0MJ4NBUBjtGA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/buffer": "^0.16.1",
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/buffer": "^0.16.3",
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/child_process/node_modules/@girs/gio-2.0": {
@@ -2961,17 +2961,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/child_process/node_modules/@gjsify/buffer": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.1.tgz",
-      "integrity": "sha512-dgapws5yErcmSb2EzKau/HOx7+oRmWnq25RIBv8ujmoq42hInIy1lrkpS0zqJtktqJEVO0yZi3JVedVkH/pzlw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.3.tgz",
+      "integrity": "sha512-dGzEBnIvm98W2Je8nWBH2k4ctHUerqZ8ABLr6QJ3JZHUaoYdQASQwVxsfzzxfkFu5/i/IEL/cNZVEKGet8sfeg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/child_process/node_modules/@gjsify/buffer/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -3041,17 +3041,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/child_process/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/child_process/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -3121,9 +3121,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/child_process/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -3193,25 +3193,25 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/cluster": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/cluster/-/cluster-0.16.1.tgz",
-      "integrity": "sha512-Ho5ytZj8rLZGBj/nGvv4bIK+H0YFGpoUOmF34pXuaKXRNezrFQeITl4ZcmAjVlsttUjezZWD90YdNzvuzPaIZQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/cluster/-/cluster-0.16.3.tgz",
+      "integrity": "sha512-p4ZT86eWLMxpRyfUP1OuYKnHwIIOdxhqBF9lwWVcMaIel1sMx9LjAIjgqiigmJCvO0bbIXjss9LOIYXox4MZ/Q==",
       "dependencies": {
-        "@gjsify/events": "^0.16.1"
+        "@gjsify/events": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/cluster/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/cluster/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -3329,29 +3329,29 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/console": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/console/-/console-0.16.1.tgz",
-      "integrity": "sha512-QI4X3eWBc8+QL/cBQJi7tMxbKMKxudNJYnm/wk+iBvL2tSqMxWfSaxFW/ftntluTUQlm6N1e0x6/YZAshnMWgg=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/console/-/console-0.16.3.tgz",
+      "integrity": "sha512-6qDtkJM/LDiFu/CS4COGAnHY5xxD9Vbe9LbN60ZI4o2p31p68vmzFp7Jo70b1pQohl6KheYGpJnO5y0KFURa/Q=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/constants": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/constants/-/constants-0.16.1.tgz",
-      "integrity": "sha512-+v8wNWKrAi8uYhStgCFI2NiC7+5Q+FPir9Z44rr363GyA/aPPMsMwvZKncnvgHSfF/dFY8Fw2vtXF5APpwkC5A==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/constants/-/constants-0.16.3.tgz",
+      "integrity": "sha512-CS90Ivl/JsVg5ESr9r3D++pA1IR8jvhp/Sn2Zclj4xkz8n6UGDGyZ4d3/2q3fW75iyzWHECwRAvViAvl974RWw==",
       "dependencies": {
-        "@gjsify/crypto": "^0.16.1",
-        "@gjsify/fs": "^0.16.1",
-        "@gjsify/os": "^0.16.1"
+        "@gjsify/crypto": "^0.16.3",
+        "@gjsify/fs": "^0.16.3",
+        "@gjsify/os": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/constants/node_modules/@gjsify/crypto": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/crypto/-/crypto-0.16.1.tgz",
-      "integrity": "sha512-K2ubUhOpc193gvG/Ct4XGQqqJmQNP4lKBzD53dTfjAVlgo6h4c2RNQwZFp42Nwz3MzU9SkyqgsGEj34OmjDh0Q==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/crypto/-/crypto-0.16.3.tgz",
+      "integrity": "sha512-dyqf6ULf6wKGu0qNcGp4jwBSdScAN9WI968ixoRziNZIvAtyIiBRrZ0vHbE0Os7/5OYO4jtfU5/RQxXTGpdVaw==",
       "dependencies": {
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/buffer": "^0.16.1",
-        "@gjsify/stream": "^0.16.1",
-        "@gjsify/utils": "^0.16.1",
+        "@gjsify/buffer": "^0.16.3",
+        "@gjsify/stream": "^0.16.3",
+        "@gjsify/utils": "^0.16.3",
         "@noble/hashes": "^2.2.0"
       }
     },
@@ -3416,17 +3416,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/constants/node_modules/@gjsify/crypto/node_modules/@gjsify/buffer": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.1.tgz",
-      "integrity": "sha512-dgapws5yErcmSb2EzKau/HOx7+oRmWnq25RIBv8ujmoq42hInIy1lrkpS0zqJtktqJEVO0yZi3JVedVkH/pzlw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.3.tgz",
+      "integrity": "sha512-dGzEBnIvm98W2Je8nWBH2k4ctHUerqZ8ABLr6QJ3JZHUaoYdQASQwVxsfzzxfkFu5/i/IEL/cNZVEKGet8sfeg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/constants/node_modules/@gjsify/crypto/node_modules/@gjsify/buffer/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -3526,27 +3526,27 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/constants/node_modules/@gjsify/crypto/node_modules/@gjsify/stream": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.1.tgz",
-      "integrity": "sha512-KFm9H/6uLmmQoPtMAI9y9Or4aLip0qf24lQxU0wDTuIEcbMHpXN9vc4fHDrz5Qg03CffkfvHzh2jA8RDQQ9A6g==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.3.tgz",
+      "integrity": "sha512-jk2DfOKMdOPpU+Pjq5QE6qr9xVrQ3eXsepFtwLg/cGYAxG7xw/0/tI9BSinPVUF+PBEsFaX+Y6jz2HQokJsiuQ==",
       "dependencies": {
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/utils": "^0.16.1",
-        "@gjsify/web-streams": "^0.16.1"
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/utils": "^0.16.3",
+        "@gjsify/web-streams": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/constants/node_modules/@gjsify/crypto/node_modules/@gjsify/stream/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/constants/node_modules/@gjsify/crypto/node_modules/@gjsify/stream/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -3646,9 +3646,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/constants/node_modules/@gjsify/crypto/node_modules/@gjsify/stream/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -3748,17 +3748,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/constants/node_modules/@gjsify/crypto/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.1.tgz",
-      "integrity": "sha512-lBmnY/4IibT8igGmy/IrtcZQrQxZvW49cjwnIJ0Ty0GrpVgWg+8r2YE38iLj+BdVYMht8GFRPemWudRqJKN2kw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.3.tgz",
+      "integrity": "sha512-L+TQa0M2rNnvOQyvoB7ow73DEx5j8FFjKqNB0sqIRKbzYJiNXvHXngTcGjHlPKDHmBtwGL34hBBuUUzQzLZ9Gg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/constants/node_modules/@gjsify/crypto/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -3858,9 +3858,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/constants/node_modules/@gjsify/crypto/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -3965,17 +3965,17 @@
       "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/constants/node_modules/@gjsify/fs": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/fs/-/fs-0.16.1.tgz",
-      "integrity": "sha512-hkr9471qnKwgBg/o8nWbPPWBui9evukwQOP7H3hTTRPLRFoZBeiPtBuzhPsqT4qluUxba6L8xxu5VIPJAycJqw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/fs/-/fs-0.16.3.tgz",
+      "integrity": "sha512-W4b7disLST/fXZ08kpcYNpZD52irQBsM/hP7dJmG5Qm4P4oUsPbO6bpHI6oysNURt//280p24E2QwLFKh7evSA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/buffer": "^0.16.1",
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/stream": "^0.16.1",
-        "@gjsify/url": "^0.16.1",
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/buffer": "^0.16.3",
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/stream": "^0.16.3",
+        "@gjsify/url": "^0.16.3",
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/constants/node_modules/@gjsify/fs/node_modules/@girs/gio-2.0": {
@@ -4069,17 +4069,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/constants/node_modules/@gjsify/fs/node_modules/@gjsify/buffer": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.1.tgz",
-      "integrity": "sha512-dgapws5yErcmSb2EzKau/HOx7+oRmWnq25RIBv8ujmoq42hInIy1lrkpS0zqJtktqJEVO0yZi3JVedVkH/pzlw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.3.tgz",
+      "integrity": "sha512-dGzEBnIvm98W2Je8nWBH2k4ctHUerqZ8ABLr6QJ3JZHUaoYdQASQwVxsfzzxfkFu5/i/IEL/cNZVEKGet8sfeg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/constants/node_modules/@gjsify/fs/node_modules/@gjsify/buffer/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -4149,17 +4149,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/constants/node_modules/@gjsify/fs/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/constants/node_modules/@gjsify/fs/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -4229,27 +4229,27 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/constants/node_modules/@gjsify/fs/node_modules/@gjsify/stream": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.1.tgz",
-      "integrity": "sha512-KFm9H/6uLmmQoPtMAI9y9Or4aLip0qf24lQxU0wDTuIEcbMHpXN9vc4fHDrz5Qg03CffkfvHzh2jA8RDQQ9A6g==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.3.tgz",
+      "integrity": "sha512-jk2DfOKMdOPpU+Pjq5QE6qr9xVrQ3eXsepFtwLg/cGYAxG7xw/0/tI9BSinPVUF+PBEsFaX+Y6jz2HQokJsiuQ==",
       "dependencies": {
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/utils": "^0.16.1",
-        "@gjsify/web-streams": "^0.16.1"
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/utils": "^0.16.3",
+        "@gjsify/web-streams": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/constants/node_modules/@gjsify/fs/node_modules/@gjsify/stream/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/constants/node_modules/@gjsify/fs/node_modules/@gjsify/stream/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -4319,9 +4319,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/constants/node_modules/@gjsify/fs/node_modules/@gjsify/stream/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -4391,17 +4391,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/constants/node_modules/@gjsify/fs/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.1.tgz",
-      "integrity": "sha512-lBmnY/4IibT8igGmy/IrtcZQrQxZvW49cjwnIJ0Ty0GrpVgWg+8r2YE38iLj+BdVYMht8GFRPemWudRqJKN2kw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.3.tgz",
+      "integrity": "sha512-L+TQa0M2rNnvOQyvoB7ow73DEx5j8FFjKqNB0sqIRKbzYJiNXvHXngTcGjHlPKDHmBtwGL34hBBuUUzQzLZ9Gg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/constants/node_modules/@gjsify/fs/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -4471,17 +4471,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/constants/node_modules/@gjsify/fs/node_modules/@gjsify/url": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.16.1.tgz",
-      "integrity": "sha512-+enwAVUFMLMrca9spA2sjHcZJuHLWMSLqG5TuLRbpNcKAhnUxkAK1vERZ10rj8Y9Jo639Y+q0t9vqUxHR+sKmg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.16.3.tgz",
+      "integrity": "sha512-7oNt6TYBQCzKcf/7D8v2nBqw/D+a0rzuQ1J4jITqO/nHYQXGt4oV7RaLa7sC6EHNaoj0l9sUKPP3IMhm2+RNNw==",
       "dependencies": {
         "@girs/glib-2.0": "^4.1.0"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/constants/node_modules/@gjsify/fs/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -4551,13 +4551,13 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/constants/node_modules/@gjsify/os": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/os/-/os-0.16.1.tgz",
-      "integrity": "sha512-SUOLch9m9vQx6amYIZS+kqT8khyWwYuooXkGhNVqZAbs397jcVK9goQTQrurgKNmyhcdzt5GwKbdjU6AEXr8iA==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/os/-/os-0.16.3.tgz",
+      "integrity": "sha512-vUspqPB6s6+Z3urQ7mCx+9Mw+6LhBJMhuESiay7jKj6yF7NiNT3+dKdXcdoetyHERCIPesHBu+CJsyBU5bJuBg==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/constants/node_modules/@gjsify/os/node_modules/@girs/gio-2.0": {
@@ -4651,9 +4651,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/constants/node_modules/@gjsify/os/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -4723,14 +4723,14 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/crypto": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/crypto/-/crypto-0.16.1.tgz",
-      "integrity": "sha512-K2ubUhOpc193gvG/Ct4XGQqqJmQNP4lKBzD53dTfjAVlgo6h4c2RNQwZFp42Nwz3MzU9SkyqgsGEj34OmjDh0Q==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/crypto/-/crypto-0.16.3.tgz",
+      "integrity": "sha512-dyqf6ULf6wKGu0qNcGp4jwBSdScAN9WI968ixoRziNZIvAtyIiBRrZ0vHbE0Os7/5OYO4jtfU5/RQxXTGpdVaw==",
       "dependencies": {
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/buffer": "^0.16.1",
-        "@gjsify/stream": "^0.16.1",
-        "@gjsify/utils": "^0.16.1",
+        "@gjsify/buffer": "^0.16.3",
+        "@gjsify/stream": "^0.16.3",
+        "@gjsify/utils": "^0.16.3",
         "@noble/hashes": "^2.2.0"
       }
     },
@@ -4795,17 +4795,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/crypto/node_modules/@gjsify/buffer": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.1.tgz",
-      "integrity": "sha512-dgapws5yErcmSb2EzKau/HOx7+oRmWnq25RIBv8ujmoq42hInIy1lrkpS0zqJtktqJEVO0yZi3JVedVkH/pzlw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.3.tgz",
+      "integrity": "sha512-dGzEBnIvm98W2Je8nWBH2k4ctHUerqZ8ABLr6QJ3JZHUaoYdQASQwVxsfzzxfkFu5/i/IEL/cNZVEKGet8sfeg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/crypto/node_modules/@gjsify/buffer/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -4905,27 +4905,27 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/crypto/node_modules/@gjsify/stream": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.1.tgz",
-      "integrity": "sha512-KFm9H/6uLmmQoPtMAI9y9Or4aLip0qf24lQxU0wDTuIEcbMHpXN9vc4fHDrz5Qg03CffkfvHzh2jA8RDQQ9A6g==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.3.tgz",
+      "integrity": "sha512-jk2DfOKMdOPpU+Pjq5QE6qr9xVrQ3eXsepFtwLg/cGYAxG7xw/0/tI9BSinPVUF+PBEsFaX+Y6jz2HQokJsiuQ==",
       "dependencies": {
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/utils": "^0.16.1",
-        "@gjsify/web-streams": "^0.16.1"
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/utils": "^0.16.3",
+        "@gjsify/web-streams": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/crypto/node_modules/@gjsify/stream/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/crypto/node_modules/@gjsify/stream/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -5025,9 +5025,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/crypto/node_modules/@gjsify/stream/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -5127,17 +5127,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/crypto/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.1.tgz",
-      "integrity": "sha512-lBmnY/4IibT8igGmy/IrtcZQrQxZvW49cjwnIJ0Ty0GrpVgWg+8r2YE38iLj+BdVYMht8GFRPemWudRqJKN2kw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.3.tgz",
+      "integrity": "sha512-L+TQa0M2rNnvOQyvoB7ow73DEx5j8FFjKqNB0sqIRKbzYJiNXvHXngTcGjHlPKDHmBtwGL34hBBuUUzQzLZ9Gg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/crypto/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -5237,9 +5237,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/crypto/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -5344,15 +5344,15 @@
       "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/dgram": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dgram/-/dgram-0.16.1.tgz",
-      "integrity": "sha512-ACWwzAgZNJP7Ze5WTEFffzbUtIi0CLdw69f8mIar/brnMTMDgNbey2p2TY4u8GJ0S+T3bdn0PgENM9dcthmPvw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dgram/-/dgram-0.16.3.tgz",
+      "integrity": "sha512-JPJ1N/fQSMbIlMlolb/xIAzgJynOCjEXQp8tKh26htDxdmU5xLa+O7ZFKgvFbmiFXhIq6XLnxMDLApluPjbMsA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/buffer": "^0.16.1",
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/buffer": "^0.16.3",
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/dgram/node_modules/@girs/gio-2.0": {
@@ -5446,17 +5446,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/dgram/node_modules/@gjsify/buffer": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.1.tgz",
-      "integrity": "sha512-dgapws5yErcmSb2EzKau/HOx7+oRmWnq25RIBv8ujmoq42hInIy1lrkpS0zqJtktqJEVO0yZi3JVedVkH/pzlw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.3.tgz",
+      "integrity": "sha512-dGzEBnIvm98W2Je8nWBH2k4ctHUerqZ8ABLr6QJ3JZHUaoYdQASQwVxsfzzxfkFu5/i/IEL/cNZVEKGet8sfeg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/dgram/node_modules/@gjsify/buffer/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -5526,17 +5526,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/dgram/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/dgram/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -5606,9 +5606,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/dgram/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -5678,19 +5678,19 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/diagnostics_channel": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/diagnostics_channel/-/diagnostics_channel-0.16.1.tgz",
-      "integrity": "sha512-JBOyESlFSNOli97sx55diPEnmZfy7x5H7uVJhuqhn3rlo7s9Hog4aCpgp1d2sA98JZgK9LEepl6W79Q0DICwtw=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/diagnostics_channel/-/diagnostics_channel-0.16.3.tgz",
+      "integrity": "sha512-9H5G4m8XB8yslzjIOFpX/axDDK2HZlwplD4LwI7PPuW/8OcvOtuU1nqSdL8NwLF7yr5wLdibnydcH3iRdRcitg=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/dns": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dns/-/dns-0.16.1.tgz",
-      "integrity": "sha512-g1+Wazz044W2lOtfmdcUD7z+zEHHFa1lOxnfpaRDSLQOYeiOK69vGboBUN0SRhucOM0Ql9j376OlmoFZXDyHcA==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dns/-/dns-0.16.3.tgz",
+      "integrity": "sha512-a6JDz2GMY0BKKZkUrqCEiaUpzpKRASHpzPcR2IX+MGjdPMS/is0S93YFnL4lifBazxGjMQhalRHknxyvnQyMxQ==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/net": "^0.16.1",
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/net": "^0.16.3",
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/dns/node_modules/@girs/gio-2.0": {
@@ -5784,30 +5784,30 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/dns/node_modules/@gjsify/net": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/net/-/net-0.16.1.tgz",
-      "integrity": "sha512-fMFXtl0KAt+IEUwU+TuiB70kyYi7J8xu4MURDo9aXI1yzIblCXyMxRw/fGuRECLpsAeJONl/6ckIlPrst/Hf9g==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/net/-/net-0.16.3.tgz",
+      "integrity": "sha512-mFVIDc38GAPz1TKNE5zRP0SacVMAucaC/YvNQtpR6ISs/EicfWvgWt+XDckYgizKSmL2dJlYkGKnlwUbxZ9jtg==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/buffer": "^0.16.1",
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/stream": "^0.16.1",
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/buffer": "^0.16.3",
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/stream": "^0.16.3",
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/dns/node_modules/@gjsify/net/node_modules/@gjsify/buffer": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.1.tgz",
-      "integrity": "sha512-dgapws5yErcmSb2EzKau/HOx7+oRmWnq25RIBv8ujmoq42hInIy1lrkpS0zqJtktqJEVO0yZi3JVedVkH/pzlw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.3.tgz",
+      "integrity": "sha512-dGzEBnIvm98W2Je8nWBH2k4ctHUerqZ8ABLr6QJ3JZHUaoYdQASQwVxsfzzxfkFu5/i/IEL/cNZVEKGet8sfeg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/dns/node_modules/@gjsify/net/node_modules/@gjsify/buffer/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -5877,17 +5877,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/dns/node_modules/@gjsify/net/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/dns/node_modules/@gjsify/net/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -5957,27 +5957,27 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/dns/node_modules/@gjsify/net/node_modules/@gjsify/stream": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.1.tgz",
-      "integrity": "sha512-KFm9H/6uLmmQoPtMAI9y9Or4aLip0qf24lQxU0wDTuIEcbMHpXN9vc4fHDrz5Qg03CffkfvHzh2jA8RDQQ9A6g==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.3.tgz",
+      "integrity": "sha512-jk2DfOKMdOPpU+Pjq5QE6qr9xVrQ3eXsepFtwLg/cGYAxG7xw/0/tI9BSinPVUF+PBEsFaX+Y6jz2HQokJsiuQ==",
       "dependencies": {
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/utils": "^0.16.1",
-        "@gjsify/web-streams": "^0.16.1"
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/utils": "^0.16.3",
+        "@gjsify/web-streams": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/dns/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/dns/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -6047,9 +6047,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/dns/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -6119,17 +6119,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/dns/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.1.tgz",
-      "integrity": "sha512-lBmnY/4IibT8igGmy/IrtcZQrQxZvW49cjwnIJ0Ty0GrpVgWg+8r2YE38iLj+BdVYMht8GFRPemWudRqJKN2kw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.3.tgz",
+      "integrity": "sha512-L+TQa0M2rNnvOQyvoB7ow73DEx5j8FFjKqNB0sqIRKbzYJiNXvHXngTcGjHlPKDHmBtwGL34hBBuUUzQzLZ9Gg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/dns/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -6199,9 +6199,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/dns/node_modules/@gjsify/net/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -6271,9 +6271,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/dns/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -6343,25 +6343,25 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/domain": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/domain/-/domain-0.16.1.tgz",
-      "integrity": "sha512-Gn3mPWH0/QIPJ1h5ze4dXN7HfUMQldCabikdfhlDF1xDWhU+Jk98SKkTAoLsoiSke+iVLkDu6n5WFgWrtXKHqA==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/domain/-/domain-0.16.3.tgz",
+      "integrity": "sha512-ToB1Ag1bglZgc5RWOWpgXh8fSe3l7Lbwvw/DkaVJQjh4R9H36j/6giJHdOVLWAnlD/ZiHTR/LyfVn7NioRtoRA==",
       "dependencies": {
-        "@gjsify/events": "^0.16.1"
+        "@gjsify/events": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/domain/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/domain/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -6479,17 +6479,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -6607,17 +6607,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/fs": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/fs/-/fs-0.16.1.tgz",
-      "integrity": "sha512-hkr9471qnKwgBg/o8nWbPPWBui9evukwQOP7H3hTTRPLRFoZBeiPtBuzhPsqT4qluUxba6L8xxu5VIPJAycJqw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/fs/-/fs-0.16.3.tgz",
+      "integrity": "sha512-W4b7disLST/fXZ08kpcYNpZD52irQBsM/hP7dJmG5Qm4P4oUsPbO6bpHI6oysNURt//280p24E2QwLFKh7evSA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/buffer": "^0.16.1",
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/stream": "^0.16.1",
-        "@gjsify/url": "^0.16.1",
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/buffer": "^0.16.3",
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/stream": "^0.16.3",
+        "@gjsify/url": "^0.16.3",
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/fs/node_modules/@girs/gio-2.0": {
@@ -6711,17 +6711,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/fs/node_modules/@gjsify/buffer": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.1.tgz",
-      "integrity": "sha512-dgapws5yErcmSb2EzKau/HOx7+oRmWnq25RIBv8ujmoq42hInIy1lrkpS0zqJtktqJEVO0yZi3JVedVkH/pzlw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.3.tgz",
+      "integrity": "sha512-dGzEBnIvm98W2Je8nWBH2k4ctHUerqZ8ABLr6QJ3JZHUaoYdQASQwVxsfzzxfkFu5/i/IEL/cNZVEKGet8sfeg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/fs/node_modules/@gjsify/buffer/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -6791,17 +6791,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/fs/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/fs/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -6871,27 +6871,27 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/fs/node_modules/@gjsify/stream": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.1.tgz",
-      "integrity": "sha512-KFm9H/6uLmmQoPtMAI9y9Or4aLip0qf24lQxU0wDTuIEcbMHpXN9vc4fHDrz5Qg03CffkfvHzh2jA8RDQQ9A6g==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.3.tgz",
+      "integrity": "sha512-jk2DfOKMdOPpU+Pjq5QE6qr9xVrQ3eXsepFtwLg/cGYAxG7xw/0/tI9BSinPVUF+PBEsFaX+Y6jz2HQokJsiuQ==",
       "dependencies": {
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/utils": "^0.16.1",
-        "@gjsify/web-streams": "^0.16.1"
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/utils": "^0.16.3",
+        "@gjsify/web-streams": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/fs/node_modules/@gjsify/stream/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/fs/node_modules/@gjsify/stream/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -6961,9 +6961,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/fs/node_modules/@gjsify/stream/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -7033,17 +7033,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/fs/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.1.tgz",
-      "integrity": "sha512-lBmnY/4IibT8igGmy/IrtcZQrQxZvW49cjwnIJ0Ty0GrpVgWg+8r2YE38iLj+BdVYMht8GFRPemWudRqJKN2kw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.3.tgz",
+      "integrity": "sha512-L+TQa0M2rNnvOQyvoB7ow73DEx5j8FFjKqNB0sqIRKbzYJiNXvHXngTcGjHlPKDHmBtwGL34hBBuUUzQzLZ9Gg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/fs/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -7113,17 +7113,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/fs/node_modules/@gjsify/url": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.16.1.tgz",
-      "integrity": "sha512-+enwAVUFMLMrca9spA2sjHcZJuHLWMSLqG5TuLRbpNcKAhnUxkAK1vERZ10rj8Y9Jo639Y+q0t9vqUxHR+sKmg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.16.3.tgz",
+      "integrity": "sha512-7oNt6TYBQCzKcf/7D8v2nBqw/D+a0rzuQ1J4jITqO/nHYQXGt4oV7RaLa7sC6EHNaoj0l9sUKPP3IMhm2+RNNw==",
       "dependencies": {
         "@girs/glib-2.0": "^4.1.0"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/fs/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -7193,20 +7193,20 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/http": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/http/-/http-0.16.1.tgz",
-      "integrity": "sha512-LoMdpA5z5nhEH+Rbn5LOuNUHQ/knzcQMA2WvxFMTm1iyWrfgYdaDiDoMMHcOq52QnF7rR79c2KA0ehyOntY1Rg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/http/-/http-0.16.3.tgz",
+      "integrity": "sha512-SLdgQz6NhtH1HG8BfoBN9ozf4XkTkkW92YT/NJjvND6uk3oL9C4WvAmv/YEttaHjHfWoaNog1R06Rg5/UHUtEg==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
         "@girs/soup-3.0": "^4.1.0",
-        "@gjsify/buffer": "^0.16.1",
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/http-soup-bridge": "^0.16.1",
-        "@gjsify/net": "^0.16.1",
-        "@gjsify/stream": "^0.16.1",
-        "@gjsify/url": "^0.16.1",
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/buffer": "^0.16.3",
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/http-soup-bridge": "^0.16.3",
+        "@gjsify/net": "^0.16.3",
+        "@gjsify/stream": "^0.16.3",
+        "@gjsify/url": "^0.16.3",
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/http/node_modules/@girs/gio-2.0": {
@@ -7352,17 +7352,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/http/node_modules/@gjsify/buffer": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.1.tgz",
-      "integrity": "sha512-dgapws5yErcmSb2EzKau/HOx7+oRmWnq25RIBv8ujmoq42hInIy1lrkpS0zqJtktqJEVO0yZi3JVedVkH/pzlw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.3.tgz",
+      "integrity": "sha512-dGzEBnIvm98W2Je8nWBH2k4ctHUerqZ8ABLr6QJ3JZHUaoYdQASQwVxsfzzxfkFu5/i/IEL/cNZVEKGet8sfeg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/http/node_modules/@gjsify/buffer/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -7432,17 +7432,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/http/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/http/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -7512,9 +7512,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/http/node_modules/@gjsify/http-soup-bridge": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge/-/http-soup-bridge-0.16.1.tgz",
-      "integrity": "sha512-WRWNT6LmkNaacSMo+R2x2QFVqld9H2grjM6RnEG2rvCb3M9horIsuM7kGNjlUpWor3vb7KQ8KVJ8BOtoo+MXoQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge/-/http-soup-bridge-0.16.3.tgz",
+      "integrity": "sha512-PUf2QVNAZDPJuRsEdwgxs4/bV+iP0SSlcterP0benh9xUjFWB6RDuv3rsJWtaNdnleD+lky9zGpYJbG+MpkhqA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/gjs": "^4.1.0",
@@ -7554,30 +7554,30 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/http/node_modules/@gjsify/net": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/net/-/net-0.16.1.tgz",
-      "integrity": "sha512-fMFXtl0KAt+IEUwU+TuiB70kyYi7J8xu4MURDo9aXI1yzIblCXyMxRw/fGuRECLpsAeJONl/6ckIlPrst/Hf9g==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/net/-/net-0.16.3.tgz",
+      "integrity": "sha512-mFVIDc38GAPz1TKNE5zRP0SacVMAucaC/YvNQtpR6ISs/EicfWvgWt+XDckYgizKSmL2dJlYkGKnlwUbxZ9jtg==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/buffer": "^0.16.1",
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/stream": "^0.16.1",
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/buffer": "^0.16.3",
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/stream": "^0.16.3",
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/buffer": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.1.tgz",
-      "integrity": "sha512-dgapws5yErcmSb2EzKau/HOx7+oRmWnq25RIBv8ujmoq42hInIy1lrkpS0zqJtktqJEVO0yZi3JVedVkH/pzlw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.3.tgz",
+      "integrity": "sha512-dGzEBnIvm98W2Je8nWBH2k4ctHUerqZ8ABLr6QJ3JZHUaoYdQASQwVxsfzzxfkFu5/i/IEL/cNZVEKGet8sfeg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/buffer/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -7647,17 +7647,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -7727,27 +7727,27 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/stream": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.1.tgz",
-      "integrity": "sha512-KFm9H/6uLmmQoPtMAI9y9Or4aLip0qf24lQxU0wDTuIEcbMHpXN9vc4fHDrz5Qg03CffkfvHzh2jA8RDQQ9A6g==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.3.tgz",
+      "integrity": "sha512-jk2DfOKMdOPpU+Pjq5QE6qr9xVrQ3eXsepFtwLg/cGYAxG7xw/0/tI9BSinPVUF+PBEsFaX+Y6jz2HQokJsiuQ==",
       "dependencies": {
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/utils": "^0.16.1",
-        "@gjsify/web-streams": "^0.16.1"
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/utils": "^0.16.3",
+        "@gjsify/web-streams": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -7817,9 +7817,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -7889,17 +7889,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.1.tgz",
-      "integrity": "sha512-lBmnY/4IibT8igGmy/IrtcZQrQxZvW49cjwnIJ0Ty0GrpVgWg+8r2YE38iLj+BdVYMht8GFRPemWudRqJKN2kw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.3.tgz",
+      "integrity": "sha512-L+TQa0M2rNnvOQyvoB7ow73DEx5j8FFjKqNB0sqIRKbzYJiNXvHXngTcGjHlPKDHmBtwGL34hBBuUUzQzLZ9Gg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -7969,9 +7969,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -8041,27 +8041,27 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/http/node_modules/@gjsify/stream": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.1.tgz",
-      "integrity": "sha512-KFm9H/6uLmmQoPtMAI9y9Or4aLip0qf24lQxU0wDTuIEcbMHpXN9vc4fHDrz5Qg03CffkfvHzh2jA8RDQQ9A6g==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.3.tgz",
+      "integrity": "sha512-jk2DfOKMdOPpU+Pjq5QE6qr9xVrQ3eXsepFtwLg/cGYAxG7xw/0/tI9BSinPVUF+PBEsFaX+Y6jz2HQokJsiuQ==",
       "dependencies": {
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/utils": "^0.16.1",
-        "@gjsify/web-streams": "^0.16.1"
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/utils": "^0.16.3",
+        "@gjsify/web-streams": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/http/node_modules/@gjsify/stream/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/http/node_modules/@gjsify/stream/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -8131,9 +8131,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/http/node_modules/@gjsify/stream/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -8203,17 +8203,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/http/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.1.tgz",
-      "integrity": "sha512-lBmnY/4IibT8igGmy/IrtcZQrQxZvW49cjwnIJ0Ty0GrpVgWg+8r2YE38iLj+BdVYMht8GFRPemWudRqJKN2kw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.3.tgz",
+      "integrity": "sha512-L+TQa0M2rNnvOQyvoB7ow73DEx5j8FFjKqNB0sqIRKbzYJiNXvHXngTcGjHlPKDHmBtwGL34hBBuUUzQzLZ9Gg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/http/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -8283,17 +8283,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/http/node_modules/@gjsify/url": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.16.1.tgz",
-      "integrity": "sha512-+enwAVUFMLMrca9spA2sjHcZJuHLWMSLqG5TuLRbpNcKAhnUxkAK1vERZ10rj8Y9Jo639Y+q0t9vqUxHR+sKmg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.16.3.tgz",
+      "integrity": "sha512-7oNt6TYBQCzKcf/7D8v2nBqw/D+a0rzuQ1J4jITqO/nHYQXGt4oV7RaLa7sC6EHNaoj0l9sUKPP3IMhm2+RNNw==",
       "dependencies": {
         "@girs/glib-2.0": "^4.1.0"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/http/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -8363,17 +8363,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/http2": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/http2/-/http2-0.16.1.tgz",
-      "integrity": "sha512-BRGYa7BFWp/qwnntQX0M2WLr8IvQ5g0TwO+fWdDbre39z/mwo1xPwlwj/hQh0eZFq1Xb3ZXEyyoJgTRc3Df17w==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/http2/-/http2-0.16.3.tgz",
+      "integrity": "sha512-cpCtqHY/jh806pTRs7cOBwl+bOGAqBJ9+omuW/pEN+TRrIUXa5Ibpt+JB1Zzt+0i7+fj0ralsQspGL9Ppm365A==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
         "@girs/gobject-2.0": "^4.1.0",
         "@girs/soup-3.0": "^4.1.0",
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/http2-native": "^0.16.1",
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/http2-native": "^0.16.3",
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/http2/node_modules/@girs/gio-2.0": {
@@ -8522,17 +8522,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/http2/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/http2/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -8584,9 +8584,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/http2/node_modules/@gjsify/http2-native": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/http2-native/-/http2-native-0.16.1.tgz",
-      "integrity": "sha512-A2JwYfgJKnnyTT81Fc52br2mh0d2zbnCq47doqhB7FTO0x7p4pQZVdcqFv2Sw7tT/jzlr/o0VxNJFEUVn0/4IQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/http2-native/-/http2-native-0.16.3.tgz",
+      "integrity": "sha512-6wUj4wXG/X8EAMH55TqUokSdB2Ezm5LI0L7RPBsCqv+/uiSwr1yRPIAvRBJH9XrGg4zwSFprR5QGUXQL5kuLVw==",
       "dependencies": {
         "@girs/gjs": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
@@ -8615,9 +8615,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/http2/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -8669,29 +8669,29 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/https/-/https-0.16.1.tgz",
-      "integrity": "sha512-A/HBcDZovpZLMO7lVUPKjM01os30Cgd2m0rxLoVjGZNST3pM6Ii6GuVWc5wQ+CLEntAOCF+32iyEYMGPKNrKVw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/https/-/https-0.16.3.tgz",
+      "integrity": "sha512-PbHV4Tuzg+e60FHqKOqPwa1ogoUqH4HYfkdwKLmupU37SXVBZZGbXB+dE2hvTKwcClpiTf1Aj8IBKPul3PbwKw==",
       "dependencies": {
-        "@gjsify/http": "^0.16.1",
-        "@gjsify/tls": "^0.16.1"
+        "@gjsify/http": "^0.16.3",
+        "@gjsify/tls": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/http": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/http/-/http-0.16.1.tgz",
-      "integrity": "sha512-LoMdpA5z5nhEH+Rbn5LOuNUHQ/knzcQMA2WvxFMTm1iyWrfgYdaDiDoMMHcOq52QnF7rR79c2KA0ehyOntY1Rg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/http/-/http-0.16.3.tgz",
+      "integrity": "sha512-SLdgQz6NhtH1HG8BfoBN9ozf4XkTkkW92YT/NJjvND6uk3oL9C4WvAmv/YEttaHjHfWoaNog1R06Rg5/UHUtEg==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
         "@girs/soup-3.0": "^4.1.0",
-        "@gjsify/buffer": "^0.16.1",
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/http-soup-bridge": "^0.16.1",
-        "@gjsify/net": "^0.16.1",
-        "@gjsify/stream": "^0.16.1",
-        "@gjsify/url": "^0.16.1",
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/buffer": "^0.16.3",
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/http-soup-bridge": "^0.16.3",
+        "@gjsify/net": "^0.16.3",
+        "@gjsify/stream": "^0.16.3",
+        "@gjsify/url": "^0.16.3",
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/http/node_modules/@girs/gio-2.0": {
@@ -8837,17 +8837,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/http/node_modules/@gjsify/buffer": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.1.tgz",
-      "integrity": "sha512-dgapws5yErcmSb2EzKau/HOx7+oRmWnq25RIBv8ujmoq42hInIy1lrkpS0zqJtktqJEVO0yZi3JVedVkH/pzlw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.3.tgz",
+      "integrity": "sha512-dGzEBnIvm98W2Je8nWBH2k4ctHUerqZ8ABLr6QJ3JZHUaoYdQASQwVxsfzzxfkFu5/i/IEL/cNZVEKGet8sfeg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/http/node_modules/@gjsify/buffer/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -8917,17 +8917,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/http/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/http/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -8997,9 +8997,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/http/node_modules/@gjsify/http-soup-bridge": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge/-/http-soup-bridge-0.16.1.tgz",
-      "integrity": "sha512-WRWNT6LmkNaacSMo+R2x2QFVqld9H2grjM6RnEG2rvCb3M9horIsuM7kGNjlUpWor3vb7KQ8KVJ8BOtoo+MXoQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge/-/http-soup-bridge-0.16.3.tgz",
+      "integrity": "sha512-PUf2QVNAZDPJuRsEdwgxs4/bV+iP0SSlcterP0benh9xUjFWB6RDuv3rsJWtaNdnleD+lky9zGpYJbG+MpkhqA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/gjs": "^4.1.0",
@@ -9039,30 +9039,30 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/http/node_modules/@gjsify/net": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/net/-/net-0.16.1.tgz",
-      "integrity": "sha512-fMFXtl0KAt+IEUwU+TuiB70kyYi7J8xu4MURDo9aXI1yzIblCXyMxRw/fGuRECLpsAeJONl/6ckIlPrst/Hf9g==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/net/-/net-0.16.3.tgz",
+      "integrity": "sha512-mFVIDc38GAPz1TKNE5zRP0SacVMAucaC/YvNQtpR6ISs/EicfWvgWt+XDckYgizKSmL2dJlYkGKnlwUbxZ9jtg==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/buffer": "^0.16.1",
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/stream": "^0.16.1",
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/buffer": "^0.16.3",
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/stream": "^0.16.3",
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/buffer": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.1.tgz",
-      "integrity": "sha512-dgapws5yErcmSb2EzKau/HOx7+oRmWnq25RIBv8ujmoq42hInIy1lrkpS0zqJtktqJEVO0yZi3JVedVkH/pzlw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.3.tgz",
+      "integrity": "sha512-dGzEBnIvm98W2Je8nWBH2k4ctHUerqZ8ABLr6QJ3JZHUaoYdQASQwVxsfzzxfkFu5/i/IEL/cNZVEKGet8sfeg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/buffer/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -9132,17 +9132,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -9212,27 +9212,27 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/stream": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.1.tgz",
-      "integrity": "sha512-KFm9H/6uLmmQoPtMAI9y9Or4aLip0qf24lQxU0wDTuIEcbMHpXN9vc4fHDrz5Qg03CffkfvHzh2jA8RDQQ9A6g==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.3.tgz",
+      "integrity": "sha512-jk2DfOKMdOPpU+Pjq5QE6qr9xVrQ3eXsepFtwLg/cGYAxG7xw/0/tI9BSinPVUF+PBEsFaX+Y6jz2HQokJsiuQ==",
       "dependencies": {
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/utils": "^0.16.1",
-        "@gjsify/web-streams": "^0.16.1"
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/utils": "^0.16.3",
+        "@gjsify/web-streams": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -9302,9 +9302,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -9374,17 +9374,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.1.tgz",
-      "integrity": "sha512-lBmnY/4IibT8igGmy/IrtcZQrQxZvW49cjwnIJ0Ty0GrpVgWg+8r2YE38iLj+BdVYMht8GFRPemWudRqJKN2kw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.3.tgz",
+      "integrity": "sha512-L+TQa0M2rNnvOQyvoB7ow73DEx5j8FFjKqNB0sqIRKbzYJiNXvHXngTcGjHlPKDHmBtwGL34hBBuUUzQzLZ9Gg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -9454,9 +9454,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -9526,27 +9526,27 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/http/node_modules/@gjsify/stream": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.1.tgz",
-      "integrity": "sha512-KFm9H/6uLmmQoPtMAI9y9Or4aLip0qf24lQxU0wDTuIEcbMHpXN9vc4fHDrz5Qg03CffkfvHzh2jA8RDQQ9A6g==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.3.tgz",
+      "integrity": "sha512-jk2DfOKMdOPpU+Pjq5QE6qr9xVrQ3eXsepFtwLg/cGYAxG7xw/0/tI9BSinPVUF+PBEsFaX+Y6jz2HQokJsiuQ==",
       "dependencies": {
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/utils": "^0.16.1",
-        "@gjsify/web-streams": "^0.16.1"
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/utils": "^0.16.3",
+        "@gjsify/web-streams": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/http/node_modules/@gjsify/stream/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/http/node_modules/@gjsify/stream/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -9616,9 +9616,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/http/node_modules/@gjsify/stream/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -9688,17 +9688,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/http/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.1.tgz",
-      "integrity": "sha512-lBmnY/4IibT8igGmy/IrtcZQrQxZvW49cjwnIJ0Ty0GrpVgWg+8r2YE38iLj+BdVYMht8GFRPemWudRqJKN2kw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.3.tgz",
+      "integrity": "sha512-L+TQa0M2rNnvOQyvoB7ow73DEx5j8FFjKqNB0sqIRKbzYJiNXvHXngTcGjHlPKDHmBtwGL34hBBuUUzQzLZ9Gg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/http/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -9768,17 +9768,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/http/node_modules/@gjsify/url": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.16.1.tgz",
-      "integrity": "sha512-+enwAVUFMLMrca9spA2sjHcZJuHLWMSLqG5TuLRbpNcKAhnUxkAK1vERZ10rj8Y9Jo639Y+q0t9vqUxHR+sKmg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.16.3.tgz",
+      "integrity": "sha512-7oNt6TYBQCzKcf/7D8v2nBqw/D+a0rzuQ1J4jITqO/nHYQXGt4oV7RaLa7sC6EHNaoj0l9sUKPP3IMhm2+RNNw==",
       "dependencies": {
         "@girs/glib-2.0": "^4.1.0"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/http/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -9848,15 +9848,15 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/tls": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/tls/-/tls-0.16.1.tgz",
-      "integrity": "sha512-z8l3OICzkLc4TdCrdaaPj+FVMmQvL57qMm3gekvBhpIqMdyU4BMlrlT/65//y/msYZQLECHHzDrD4GQWDmTfvA==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/tls/-/tls-0.16.3.tgz",
+      "integrity": "sha512-GxvvmzNHZrdp7wjom5IC3CVZ7UGUiZyigs6UO6eV9Rwb1ukAgcVbIPtts56n4LghgW5a1BZGsKiRp8rSjVcfug==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/net": "^0.16.1",
-        "@gjsify/tls-native": "^0.16.1",
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/net": "^0.16.3",
+        "@gjsify/tls-native": "^0.16.3",
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/tls/node_modules/@girs/gio-2.0": {
@@ -9950,30 +9950,30 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/tls/node_modules/@gjsify/net": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/net/-/net-0.16.1.tgz",
-      "integrity": "sha512-fMFXtl0KAt+IEUwU+TuiB70kyYi7J8xu4MURDo9aXI1yzIblCXyMxRw/fGuRECLpsAeJONl/6ckIlPrst/Hf9g==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/net/-/net-0.16.3.tgz",
+      "integrity": "sha512-mFVIDc38GAPz1TKNE5zRP0SacVMAucaC/YvNQtpR6ISs/EicfWvgWt+XDckYgizKSmL2dJlYkGKnlwUbxZ9jtg==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/buffer": "^0.16.1",
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/stream": "^0.16.1",
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/buffer": "^0.16.3",
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/stream": "^0.16.3",
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/tls/node_modules/@gjsify/net/node_modules/@gjsify/buffer": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.1.tgz",
-      "integrity": "sha512-dgapws5yErcmSb2EzKau/HOx7+oRmWnq25RIBv8ujmoq42hInIy1lrkpS0zqJtktqJEVO0yZi3JVedVkH/pzlw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.3.tgz",
+      "integrity": "sha512-dGzEBnIvm98W2Je8nWBH2k4ctHUerqZ8ABLr6QJ3JZHUaoYdQASQwVxsfzzxfkFu5/i/IEL/cNZVEKGet8sfeg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/tls/node_modules/@gjsify/net/node_modules/@gjsify/buffer/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -10043,17 +10043,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/tls/node_modules/@gjsify/net/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/tls/node_modules/@gjsify/net/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -10123,27 +10123,27 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/tls/node_modules/@gjsify/net/node_modules/@gjsify/stream": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.1.tgz",
-      "integrity": "sha512-KFm9H/6uLmmQoPtMAI9y9Or4aLip0qf24lQxU0wDTuIEcbMHpXN9vc4fHDrz5Qg03CffkfvHzh2jA8RDQQ9A6g==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.3.tgz",
+      "integrity": "sha512-jk2DfOKMdOPpU+Pjq5QE6qr9xVrQ3eXsepFtwLg/cGYAxG7xw/0/tI9BSinPVUF+PBEsFaX+Y6jz2HQokJsiuQ==",
       "dependencies": {
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/utils": "^0.16.1",
-        "@gjsify/web-streams": "^0.16.1"
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/utils": "^0.16.3",
+        "@gjsify/web-streams": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/tls/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/tls/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -10213,9 +10213,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/tls/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -10285,17 +10285,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/tls/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.1.tgz",
-      "integrity": "sha512-lBmnY/4IibT8igGmy/IrtcZQrQxZvW49cjwnIJ0Ty0GrpVgWg+8r2YE38iLj+BdVYMht8GFRPemWudRqJKN2kw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.3.tgz",
+      "integrity": "sha512-L+TQa0M2rNnvOQyvoB7ow73DEx5j8FFjKqNB0sqIRKbzYJiNXvHXngTcGjHlPKDHmBtwGL34hBBuUUzQzLZ9Gg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/tls/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -10365,9 +10365,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/tls/node_modules/@gjsify/net/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -10437,9 +10437,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/tls/node_modules/@gjsify/tls-native": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/tls-native/-/tls-native-0.16.1.tgz",
-      "integrity": "sha512-y3sCToJKHuf62j+qzsTE834ujF+Lm4JzzY1OeaKoL+scqkc7iAY3OwatD6n05UJPon4iKW55YJHGVjPZFShTOg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/tls-native/-/tls-native-0.16.3.tgz",
+      "integrity": "sha512-5ImzWT07GHfL5oy0XAW6+DisYGHpHTGE0I8pmTUIQwOpxC76Z2kL0HOkaazlbHv3DSfOKhA5xjo/ekDKUF3vZg==",
       "dependencies": {
         "@girs/glib-2.0": "^4.1.0",
         "@girs/gobject-2.0": "^4.1.0"
@@ -10476,9 +10476,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/https/node_modules/@gjsify/tls/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -10548,19 +10548,19 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/inspector": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/inspector/-/inspector-0.16.1.tgz",
-      "integrity": "sha512-lRcFOCgYL1JV8Ij3/lf7oi096jfO4JWmfkPcOjHuOWB4yNdJZ/6vNFLiD+CNgfsOxFCOchhlujjFOXJqbFUnQg=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/inspector/-/inspector-0.16.3.tgz",
+      "integrity": "sha512-ODmrI0Nu3O5pVOcvppNJgI5bvlaD/TSfJrZCCFT0hf6QlcEG99MulK0vhPAPy0XAPjKGRbZ0k4B2fS2Ixo8OpQ=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/module": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/module/-/module-0.16.1.tgz",
-      "integrity": "sha512-4pZ2jFaUgUoshdaEJTUK1hTOLYz+hQvgPPiWLRxTYhjXQZuBbWeNlsi05sMFtMUSnBrbDrjfxwsRPp9+vV/KBQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/module/-/module-0.16.3.tgz",
+      "integrity": "sha512-n7hqfvpOtFlxQh3wQadE0lD2nFXiipGq8R/BUoXOVAUTEL/ACRGXkuIQjkCSe7Hu+ZdIaCvcSpLYrNroRQTl/Q==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/gjs": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/module/node_modules/@girs/gio-2.0": {
@@ -10642,9 +10642,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/module/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -10684,16 +10684,16 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/net": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/net/-/net-0.16.1.tgz",
-      "integrity": "sha512-fMFXtl0KAt+IEUwU+TuiB70kyYi7J8xu4MURDo9aXI1yzIblCXyMxRw/fGuRECLpsAeJONl/6ckIlPrst/Hf9g==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/net/-/net-0.16.3.tgz",
+      "integrity": "sha512-mFVIDc38GAPz1TKNE5zRP0SacVMAucaC/YvNQtpR6ISs/EicfWvgWt+XDckYgizKSmL2dJlYkGKnlwUbxZ9jtg==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/buffer": "^0.16.1",
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/stream": "^0.16.1",
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/buffer": "^0.16.3",
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/stream": "^0.16.3",
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/net/node_modules/@girs/gio-2.0": {
@@ -10787,17 +10787,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/net/node_modules/@gjsify/buffer": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.1.tgz",
-      "integrity": "sha512-dgapws5yErcmSb2EzKau/HOx7+oRmWnq25RIBv8ujmoq42hInIy1lrkpS0zqJtktqJEVO0yZi3JVedVkH/pzlw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.3.tgz",
+      "integrity": "sha512-dGzEBnIvm98W2Je8nWBH2k4ctHUerqZ8ABLr6QJ3JZHUaoYdQASQwVxsfzzxfkFu5/i/IEL/cNZVEKGet8sfeg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/net/node_modules/@gjsify/buffer/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -10867,17 +10867,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/net/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/net/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -10947,27 +10947,27 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/net/node_modules/@gjsify/stream": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.1.tgz",
-      "integrity": "sha512-KFm9H/6uLmmQoPtMAI9y9Or4aLip0qf24lQxU0wDTuIEcbMHpXN9vc4fHDrz5Qg03CffkfvHzh2jA8RDQQ9A6g==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.3.tgz",
+      "integrity": "sha512-jk2DfOKMdOPpU+Pjq5QE6qr9xVrQ3eXsepFtwLg/cGYAxG7xw/0/tI9BSinPVUF+PBEsFaX+Y6jz2HQokJsiuQ==",
       "dependencies": {
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/utils": "^0.16.1",
-        "@gjsify/web-streams": "^0.16.1"
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/utils": "^0.16.3",
+        "@gjsify/web-streams": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -11037,9 +11037,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -11109,17 +11109,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.1.tgz",
-      "integrity": "sha512-lBmnY/4IibT8igGmy/IrtcZQrQxZvW49cjwnIJ0Ty0GrpVgWg+8r2YE38iLj+BdVYMht8GFRPemWudRqJKN2kw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.3.tgz",
+      "integrity": "sha512-L+TQa0M2rNnvOQyvoB7ow73DEx5j8FFjKqNB0sqIRKbzYJiNXvHXngTcGjHlPKDHmBtwGL34hBBuUUzQzLZ9Gg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -11189,9 +11189,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/net/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -11261,15 +11261,15 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/node-globals": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/node-globals/-/node-globals-0.16.1.tgz",
-      "integrity": "sha512-cRmaWCOpJvXktli/j5LfH9MG3xyc2KsbjfHQplyKWc4T2Z+QuDZ/9fJRQa08W8r3JvQ1Lb+0MY97QakzrytDHA==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/node-globals/-/node-globals-0.16.3.tgz",
+      "integrity": "sha512-nTGUjCWgWlALor0j24A6YLXQeW1Q61Z3vlGQ+BT8Xf4G8n6ODJk56SRiP26cT0TYIiMwbVuW5CERFDW2AMC7tQ==",
       "dependencies": {
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/buffer": "^0.16.1",
-        "@gjsify/process": "^0.16.1",
-        "@gjsify/url": "^0.16.1",
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/buffer": "^0.16.3",
+        "@gjsify/process": "^0.16.3",
+        "@gjsify/url": "^0.16.3",
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/node-globals/node_modules/@girs/glib-2.0": {
@@ -11333,17 +11333,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/node-globals/node_modules/@gjsify/buffer": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.1.tgz",
-      "integrity": "sha512-dgapws5yErcmSb2EzKau/HOx7+oRmWnq25RIBv8ujmoq42hInIy1lrkpS0zqJtktqJEVO0yZi3JVedVkH/pzlw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.3.tgz",
+      "integrity": "sha512-dGzEBnIvm98W2Je8nWBH2k4ctHUerqZ8ABLr6QJ3JZHUaoYdQASQwVxsfzzxfkFu5/i/IEL/cNZVEKGet8sfeg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/node-globals/node_modules/@gjsify/buffer/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -11443,28 +11443,28 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/node-globals/node_modules/@gjsify/process": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/process/-/process-0.16.1.tgz",
-      "integrity": "sha512-XdaRFYRwrhltnw+rLjysdTDhC9HTNFwEpplIdCle1ROhe3/rqFpyUpKWnZ7vrgsbDTk66u0mLEZkper0LFdqYA==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/process/-/process-0.16.3.tgz",
+      "integrity": "sha512-/kdS5cL2I86Mzf/Mnovkspyf+IvxrGntKtLQGdUynRiL6Lduw8cRHVUHaB+NV0YpMSikY6oUcI8Bu8S8n6Ra6A==",
       "dependencies": {
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/string_decoder": "^0.16.1",
-        "@gjsify/terminal-native": "^0.16.1",
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/string_decoder": "^0.16.3",
+        "@gjsify/terminal-native": "^0.16.3",
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/node-globals/node_modules/@gjsify/process/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/node-globals/node_modules/@gjsify/process/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -11564,25 +11564,25 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/node-globals/node_modules/@gjsify/process/node_modules/@gjsify/string_decoder": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/string_decoder/-/string_decoder-0.16.1.tgz",
-      "integrity": "sha512-CJWri5Z/NSQn5jyav8Sd4EwOzIu5a7WVjo2c1FPWVVzftRAblBeRgI0d/V4/h+0ag3F19SatG9lgA6c205ZyxA==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/string_decoder/-/string_decoder-0.16.3.tgz",
+      "integrity": "sha512-6lnHN/rO7y+CLpiPO6wwBo/yqIuvI4OseAsokH0CecH2CWOU5k0xHwHLPOyFiyJptFd3vX2MvggzNZazx/wikw==",
       "dependencies": {
-        "@gjsify/buffer": "^0.16.1"
+        "@gjsify/buffer": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/node-globals/node_modules/@gjsify/process/node_modules/@gjsify/string_decoder/node_modules/@gjsify/buffer": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.1.tgz",
-      "integrity": "sha512-dgapws5yErcmSb2EzKau/HOx7+oRmWnq25RIBv8ujmoq42hInIy1lrkpS0zqJtktqJEVO0yZi3JVedVkH/pzlw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.3.tgz",
+      "integrity": "sha512-dGzEBnIvm98W2Je8nWBH2k4ctHUerqZ8ABLr6QJ3JZHUaoYdQASQwVxsfzzxfkFu5/i/IEL/cNZVEKGet8sfeg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/node-globals/node_modules/@gjsify/process/node_modules/@gjsify/string_decoder/node_modules/@gjsify/buffer/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -11682,9 +11682,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/node-globals/node_modules/@gjsify/process/node_modules/@gjsify/terminal-native": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native/-/terminal-native-0.16.1.tgz",
-      "integrity": "sha512-0lwVideLC0Kt226+OPjIhXZ/y6Uapn5hj0mmvFrH97LiHxJ9YOIkbaxk410CCfVaHHbpTUXJ/8EyR4Kb+WXlTQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native/-/terminal-native-0.16.3.tgz",
+      "integrity": "sha512-6E0TownC66KhgV/5cKgJ4G/lc7WrSm+FTURa0DiaJKbm8Kf2kpOYo295ZZ/2q0vNwU1+MYjn5hU8EcgsmhuPSw==",
       "dependencies": {
         "@girs/glib-2.0": "^4.1.0",
         "@girs/gobject-2.0": "^4.1.0"
@@ -11742,9 +11742,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/node-globals/node_modules/@gjsify/process/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -11844,17 +11844,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/node-globals/node_modules/@gjsify/url": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.16.1.tgz",
-      "integrity": "sha512-+enwAVUFMLMrca9spA2sjHcZJuHLWMSLqG5TuLRbpNcKAhnUxkAK1vERZ10rj8Y9Jo639Y+q0t9vqUxHR+sKmg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.16.3.tgz",
+      "integrity": "sha512-7oNt6TYBQCzKcf/7D8v2nBqw/D+a0rzuQ1J4jITqO/nHYQXGt4oV7RaLa7sC6EHNaoj0l9sUKPP3IMhm2+RNNw==",
       "dependencies": {
         "@girs/glib-2.0": "^4.1.0"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/node-globals/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -11954,13 +11954,13 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/os": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/os/-/os-0.16.1.tgz",
-      "integrity": "sha512-SUOLch9m9vQx6amYIZS+kqT8khyWwYuooXkGhNVqZAbs397jcVK9goQTQrurgKNmyhcdzt5GwKbdjU6AEXr8iA==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/os/-/os-0.16.3.tgz",
+      "integrity": "sha512-vUspqPB6s6+Z3urQ7mCx+9Mw+6LhBJMhuESiay7jKj6yF7NiNT3+dKdXcdoetyHERCIPesHBu+CJsyBU5bJuBg==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/os/node_modules/@girs/gio-2.0": {
@@ -12054,9 +12054,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/os/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -12126,38 +12126,38 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/path": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/path/-/path-0.16.1.tgz",
-      "integrity": "sha512-maICzd+q6weWGyuFwzuHgq/wXFHE9P4cstcRPTs/w0sg+b9ovvqJPjSu44AdRUYHdsox5CiOGQ4+5Plcqk1caw=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/path/-/path-0.16.3.tgz",
+      "integrity": "sha512-ilUlkHAVXaZRu5gY4zkazO4NOVMMbehjNWWs2+5eS2dl1VnRZ3gruCNTFWB+7VAv/umyN3QeYEWZ50RLe5dimA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/perf_hooks": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/perf_hooks/-/perf_hooks-0.16.1.tgz",
-      "integrity": "sha512-OpqLO1CgW48+vpgqXHIH1aCwyfyG6wnzIyCHA+4a3pZ3Mipbkwrv6yrie+7qi1kQyvRKi9m6JitmTnKBLN7pPg=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/perf_hooks/-/perf_hooks-0.16.3.tgz",
+      "integrity": "sha512-j/lLGVxEnI73jBlVxDmhwzKkOpTHEmlOEe+MYbvT9l0XeNoRTAM3OPjDh/HnI4EYdGRD5uciGBthL9BxDVjspQ=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/process": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/process/-/process-0.16.1.tgz",
-      "integrity": "sha512-XdaRFYRwrhltnw+rLjysdTDhC9HTNFwEpplIdCle1ROhe3/rqFpyUpKWnZ7vrgsbDTk66u0mLEZkper0LFdqYA==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/process/-/process-0.16.3.tgz",
+      "integrity": "sha512-/kdS5cL2I86Mzf/Mnovkspyf+IvxrGntKtLQGdUynRiL6Lduw8cRHVUHaB+NV0YpMSikY6oUcI8Bu8S8n6Ra6A==",
       "dependencies": {
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/string_decoder": "^0.16.1",
-        "@gjsify/terminal-native": "^0.16.1",
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/string_decoder": "^0.16.3",
+        "@gjsify/terminal-native": "^0.16.3",
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/process/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/process/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -12275,25 +12275,25 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/process/node_modules/@gjsify/string_decoder": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/string_decoder/-/string_decoder-0.16.1.tgz",
-      "integrity": "sha512-CJWri5Z/NSQn5jyav8Sd4EwOzIu5a7WVjo2c1FPWVVzftRAblBeRgI0d/V4/h+0ag3F19SatG9lgA6c205ZyxA==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/string_decoder/-/string_decoder-0.16.3.tgz",
+      "integrity": "sha512-6lnHN/rO7y+CLpiPO6wwBo/yqIuvI4OseAsokH0CecH2CWOU5k0xHwHLPOyFiyJptFd3vX2MvggzNZazx/wikw==",
       "dependencies": {
-        "@gjsify/buffer": "^0.16.1"
+        "@gjsify/buffer": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/process/node_modules/@gjsify/string_decoder/node_modules/@gjsify/buffer": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.1.tgz",
-      "integrity": "sha512-dgapws5yErcmSb2EzKau/HOx7+oRmWnq25RIBv8ujmoq42hInIy1lrkpS0zqJtktqJEVO0yZi3JVedVkH/pzlw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.3.tgz",
+      "integrity": "sha512-dGzEBnIvm98W2Je8nWBH2k4ctHUerqZ8ABLr6QJ3JZHUaoYdQASQwVxsfzzxfkFu5/i/IEL/cNZVEKGet8sfeg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/process/node_modules/@gjsify/string_decoder/node_modules/@gjsify/buffer/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -12411,9 +12411,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/process/node_modules/@gjsify/terminal-native": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native/-/terminal-native-0.16.1.tgz",
-      "integrity": "sha512-0lwVideLC0Kt226+OPjIhXZ/y6Uapn5hj0mmvFrH97LiHxJ9YOIkbaxk410CCfVaHHbpTUXJ/8EyR4Kb+WXlTQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native/-/terminal-native-0.16.3.tgz",
+      "integrity": "sha512-6E0TownC66KhgV/5cKgJ4G/lc7WrSm+FTURa0DiaJKbm8Kf2kpOYo295ZZ/2q0vNwU1+MYjn5hU8EcgsmhuPSw==",
       "dependencies": {
         "@girs/glib-2.0": "^4.1.0",
         "@girs/gobject-2.0": "^4.1.0"
@@ -12522,9 +12522,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/process/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -12642,30 +12642,30 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/querystring": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/querystring/-/querystring-0.16.1.tgz",
-      "integrity": "sha512-QpMO2WilMvi+ra/d9X5hvwTJf2rW6B31RFHjccdB1irgT307uVUeKcLV9Db/2wlgfxcfv+yMp8RMW59N1km2bg=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/querystring/-/querystring-0.16.3.tgz",
+      "integrity": "sha512-OgT+cIRRpS/bnw7QLudB6LZdCqKN2ULfd35kb5Cbp9afmj8rztrbXemF1g0tuymp1CWzbB7Rct61Hhoec4ROTQ=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/readline": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/readline/-/readline-0.16.1.tgz",
-      "integrity": "sha512-FIVDn1a9oNuOXidIBPtcYdT+At1bHybIZUj4slgpWZuy4XKf5qh63AaeGcsdq7NU9sq1rV6/aHLZvzCaHXumhg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/readline/-/readline-0.16.3.tgz",
+      "integrity": "sha512-osJb0K2Adx9xuvEygt3Mor4IGNSNDhs/otB+GiRNmyqAaQoJjf032IWIFximV0iFT5GnRgAJ+1viuQlqrLxihw==",
       "dependencies": {
-        "@gjsify/events": "^0.16.1"
+        "@gjsify/events": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/readline/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/readline/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -12783,9 +12783,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/sqlite": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/sqlite/-/sqlite-0.16.1.tgz",
-      "integrity": "sha512-SGHaR9vQ5vEnsC/erXTyd1Lovp3QM93OjSaSXI7KK1s6fteAFVIPoDWhcIGHdv/1t/cytlJVt+Cp51lI8Ps6gw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/sqlite/-/sqlite-0.16.3.tgz",
+      "integrity": "sha512-Aw2B4yBUjTm4kHQqNxAZzGQus6PmpE+7/OmDX+Vj7/VTYYjgkaXN214UBrg+1BdskdhHBFg77cVFeZpddbg5bw==",
       "dependencies": {
         "@girs/gda-6.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
@@ -12959,27 +12959,27 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/stream": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.1.tgz",
-      "integrity": "sha512-KFm9H/6uLmmQoPtMAI9y9Or4aLip0qf24lQxU0wDTuIEcbMHpXN9vc4fHDrz5Qg03CffkfvHzh2jA8RDQQ9A6g==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.3.tgz",
+      "integrity": "sha512-jk2DfOKMdOPpU+Pjq5QE6qr9xVrQ3eXsepFtwLg/cGYAxG7xw/0/tI9BSinPVUF+PBEsFaX+Y6jz2HQokJsiuQ==",
       "dependencies": {
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/utils": "^0.16.1",
-        "@gjsify/web-streams": "^0.16.1"
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/utils": "^0.16.3",
+        "@gjsify/web-streams": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/stream/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/stream/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -13097,9 +13097,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/stream/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -13217,17 +13217,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.1.tgz",
-      "integrity": "sha512-lBmnY/4IibT8igGmy/IrtcZQrQxZvW49cjwnIJ0Ty0GrpVgWg+8r2YE38iLj+BdVYMht8GFRPemWudRqJKN2kw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.3.tgz",
+      "integrity": "sha512-L+TQa0M2rNnvOQyvoB7ow73DEx5j8FFjKqNB0sqIRKbzYJiNXvHXngTcGjHlPKDHmBtwGL34hBBuUUzQzLZ9Gg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -13345,25 +13345,25 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/string_decoder": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/string_decoder/-/string_decoder-0.16.1.tgz",
-      "integrity": "sha512-CJWri5Z/NSQn5jyav8Sd4EwOzIu5a7WVjo2c1FPWVVzftRAblBeRgI0d/V4/h+0ag3F19SatG9lgA6c205ZyxA==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/string_decoder/-/string_decoder-0.16.3.tgz",
+      "integrity": "sha512-6lnHN/rO7y+CLpiPO6wwBo/yqIuvI4OseAsokH0CecH2CWOU5k0xHwHLPOyFiyJptFd3vX2MvggzNZazx/wikw==",
       "dependencies": {
-        "@gjsify/buffer": "^0.16.1"
+        "@gjsify/buffer": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/string_decoder/node_modules/@gjsify/buffer": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.1.tgz",
-      "integrity": "sha512-dgapws5yErcmSb2EzKau/HOx7+oRmWnq25RIBv8ujmoq42hInIy1lrkpS0zqJtktqJEVO0yZi3JVedVkH/pzlw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.3.tgz",
+      "integrity": "sha512-dGzEBnIvm98W2Je8nWBH2k4ctHUerqZ8ABLr6QJ3JZHUaoYdQASQwVxsfzzxfkFu5/i/IEL/cNZVEKGet8sfeg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/string_decoder/node_modules/@gjsify/buffer/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -13481,33 +13481,33 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/sys": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/sys/-/sys-0.16.1.tgz",
-      "integrity": "sha512-ORX/0FVGg1ayEquQ93I//uj00j81usj8nthBjrbvw3aPdebGbppSvaohl4/fPyvV9V28mCI6glT/thGv1YncgA==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/sys/-/sys-0.16.3.tgz",
+      "integrity": "sha512-auuC0dXi/fvO7s1FK02lYo7ayshvjtbk0xMB+mkylCZFYMfr4T6TDZbXRHyDz0XxiYJAZSxc2d1tY3/GIGJi7Q==",
       "dependencies": {
-        "@gjsify/util": "^0.16.1"
+        "@gjsify/util": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/sys/node_modules/@gjsify/util": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/util/-/util-0.16.1.tgz",
-      "integrity": "sha512-SMIZpx6YL7Y9iKtgT/dl6vEF7eEAXLk+cR/oOmUWHu8vD/PXOtzlbqdPUTTn2/AL1pgzzBXxk6thM180UPo2eQ=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/util/-/util-0.16.3.tgz",
+      "integrity": "sha512-5GhpvXmumjcrPUdaFiQ3iILwG00RwXLlpfcygosTaBVuW0wK0i3aUXO9H1/6xrzWQbU5ILwtdz/FQ+0cioMj3g=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/timers": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/timers/-/timers-0.16.1.tgz",
-      "integrity": "sha512-/Wg7xEx8s6mA0o2li4sUZEYgDoCUT6TOiMaw5SaDh5IGH+1HYsu4LnfRV0DQtcbBj/oiL475D+UHgoHJXqHz0Q=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/timers/-/timers-0.16.3.tgz",
+      "integrity": "sha512-YgI1AtNfpcuBlZLUpvcSlZ9XLWS3ca8esVLWuXH8Tw1nZaopVuIyOXtOUuFBSGAm5JVc0TyBStykaKwOPU9hpA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/tls": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/tls/-/tls-0.16.1.tgz",
-      "integrity": "sha512-z8l3OICzkLc4TdCrdaaPj+FVMmQvL57qMm3gekvBhpIqMdyU4BMlrlT/65//y/msYZQLECHHzDrD4GQWDmTfvA==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/tls/-/tls-0.16.3.tgz",
+      "integrity": "sha512-GxvvmzNHZrdp7wjom5IC3CVZ7UGUiZyigs6UO6eV9Rwb1ukAgcVbIPtts56n4LghgW5a1BZGsKiRp8rSjVcfug==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/net": "^0.16.1",
-        "@gjsify/tls-native": "^0.16.1",
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/net": "^0.16.3",
+        "@gjsify/tls-native": "^0.16.3",
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/tls/node_modules/@girs/gio-2.0": {
@@ -13601,30 +13601,30 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/tls/node_modules/@gjsify/net": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/net/-/net-0.16.1.tgz",
-      "integrity": "sha512-fMFXtl0KAt+IEUwU+TuiB70kyYi7J8xu4MURDo9aXI1yzIblCXyMxRw/fGuRECLpsAeJONl/6ckIlPrst/Hf9g==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/net/-/net-0.16.3.tgz",
+      "integrity": "sha512-mFVIDc38GAPz1TKNE5zRP0SacVMAucaC/YvNQtpR6ISs/EicfWvgWt+XDckYgizKSmL2dJlYkGKnlwUbxZ9jtg==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/buffer": "^0.16.1",
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/stream": "^0.16.1",
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/buffer": "^0.16.3",
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/stream": "^0.16.3",
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/tls/node_modules/@gjsify/net/node_modules/@gjsify/buffer": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.1.tgz",
-      "integrity": "sha512-dgapws5yErcmSb2EzKau/HOx7+oRmWnq25RIBv8ujmoq42hInIy1lrkpS0zqJtktqJEVO0yZi3JVedVkH/pzlw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.3.tgz",
+      "integrity": "sha512-dGzEBnIvm98W2Je8nWBH2k4ctHUerqZ8ABLr6QJ3JZHUaoYdQASQwVxsfzzxfkFu5/i/IEL/cNZVEKGet8sfeg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/tls/node_modules/@gjsify/net/node_modules/@gjsify/buffer/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -13694,17 +13694,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/tls/node_modules/@gjsify/net/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/tls/node_modules/@gjsify/net/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -13774,27 +13774,27 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/tls/node_modules/@gjsify/net/node_modules/@gjsify/stream": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.1.tgz",
-      "integrity": "sha512-KFm9H/6uLmmQoPtMAI9y9Or4aLip0qf24lQxU0wDTuIEcbMHpXN9vc4fHDrz5Qg03CffkfvHzh2jA8RDQQ9A6g==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.3.tgz",
+      "integrity": "sha512-jk2DfOKMdOPpU+Pjq5QE6qr9xVrQ3eXsepFtwLg/cGYAxG7xw/0/tI9BSinPVUF+PBEsFaX+Y6jz2HQokJsiuQ==",
       "dependencies": {
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/utils": "^0.16.1",
-        "@gjsify/web-streams": "^0.16.1"
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/utils": "^0.16.3",
+        "@gjsify/web-streams": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/tls/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/tls/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -13864,9 +13864,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/tls/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -13936,17 +13936,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/tls/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.1.tgz",
-      "integrity": "sha512-lBmnY/4IibT8igGmy/IrtcZQrQxZvW49cjwnIJ0Ty0GrpVgWg+8r2YE38iLj+BdVYMht8GFRPemWudRqJKN2kw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.3.tgz",
+      "integrity": "sha512-L+TQa0M2rNnvOQyvoB7ow73DEx5j8FFjKqNB0sqIRKbzYJiNXvHXngTcGjHlPKDHmBtwGL34hBBuUUzQzLZ9Gg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/tls/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -14016,9 +14016,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/tls/node_modules/@gjsify/net/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -14088,9 +14088,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/tls/node_modules/@gjsify/tls-native": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/tls-native/-/tls-native-0.16.1.tgz",
-      "integrity": "sha512-y3sCToJKHuf62j+qzsTE834ujF+Lm4JzzY1OeaKoL+scqkc7iAY3OwatD6n05UJPon4iKW55YJHGVjPZFShTOg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/tls-native/-/tls-native-0.16.3.tgz",
+      "integrity": "sha512-5ImzWT07GHfL5oy0XAW6+DisYGHpHTGE0I8pmTUIQwOpxC76Z2kL0HOkaazlbHv3DSfOKhA5xjo/ekDKUF3vZg==",
       "dependencies": {
         "@girs/glib-2.0": "^4.1.0",
         "@girs/gobject-2.0": "^4.1.0"
@@ -14127,9 +14127,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/tls/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -14199,13 +14199,13 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/tty": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/tty/-/tty-0.16.1.tgz",
-      "integrity": "sha512-09BYq/XsLc8uG7T2w8i6Wh1jbjz4tkzdCfHb5UXVJtxUnUoswq7FKMRn1EYJutil5UqKMhGgKJhoY9KLyaZyQg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/tty/-/tty-0.16.3.tgz",
+      "integrity": "sha512-xpCs52FqMmGfl5wB+QeGlIYtQf0NKy+aH39cLGfc9fgamxARxEiiAlJiNaYxyGvFZA7rgr4gkRJnkmNjS1fYVw==",
       "dependencies": {
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/stream": "^0.16.1",
-        "@gjsify/terminal-native": "^0.16.1"
+        "@gjsify/stream": "^0.16.3",
+        "@gjsify/terminal-native": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/tty/node_modules/@girs/glib-2.0": {
@@ -14269,27 +14269,27 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/tty/node_modules/@gjsify/stream": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.1.tgz",
-      "integrity": "sha512-KFm9H/6uLmmQoPtMAI9y9Or4aLip0qf24lQxU0wDTuIEcbMHpXN9vc4fHDrz5Qg03CffkfvHzh2jA8RDQQ9A6g==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.3.tgz",
+      "integrity": "sha512-jk2DfOKMdOPpU+Pjq5QE6qr9xVrQ3eXsepFtwLg/cGYAxG7xw/0/tI9BSinPVUF+PBEsFaX+Y6jz2HQokJsiuQ==",
       "dependencies": {
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/utils": "^0.16.1",
-        "@gjsify/web-streams": "^0.16.1"
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/utils": "^0.16.3",
+        "@gjsify/web-streams": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/tty/node_modules/@gjsify/stream/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/tty/node_modules/@gjsify/stream/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -14389,9 +14389,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/tty/node_modules/@gjsify/stream/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -14491,17 +14491,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/tty/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.1.tgz",
-      "integrity": "sha512-lBmnY/4IibT8igGmy/IrtcZQrQxZvW49cjwnIJ0Ty0GrpVgWg+8r2YE38iLj+BdVYMht8GFRPemWudRqJKN2kw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.3.tgz",
+      "integrity": "sha512-L+TQa0M2rNnvOQyvoB7ow73DEx5j8FFjKqNB0sqIRKbzYJiNXvHXngTcGjHlPKDHmBtwGL34hBBuUUzQzLZ9Gg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/tty/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -14601,9 +14601,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/tty/node_modules/@gjsify/terminal-native": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native/-/terminal-native-0.16.1.tgz",
-      "integrity": "sha512-0lwVideLC0Kt226+OPjIhXZ/y6Uapn5hj0mmvFrH97LiHxJ9YOIkbaxk410CCfVaHHbpTUXJ/8EyR4Kb+WXlTQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native/-/terminal-native-0.16.3.tgz",
+      "integrity": "sha512-6E0TownC66KhgV/5cKgJ4G/lc7WrSm+FTURa0DiaJKbm8Kf2kpOYo295ZZ/2q0vNwU1+MYjn5hU8EcgsmhuPSw==",
       "dependencies": {
         "@girs/glib-2.0": "^4.1.0",
         "@girs/gobject-2.0": "^4.1.0"
@@ -14661,9 +14661,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/url": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.16.1.tgz",
-      "integrity": "sha512-+enwAVUFMLMrca9spA2sjHcZJuHLWMSLqG5TuLRbpNcKAhnUxkAK1vERZ10rj8Y9Jo639Y+q0t9vqUxHR+sKmg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.16.3.tgz",
+      "integrity": "sha512-7oNt6TYBQCzKcf/7D8v2nBqw/D+a0rzuQ1J4jITqO/nHYQXGt4oV7RaLa7sC6EHNaoj0l9sUKPP3IMhm2+RNNw==",
       "dependencies": {
         "@girs/glib-2.0": "^4.1.0"
       }
@@ -14729,30 +14729,30 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/util": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/util/-/util-0.16.1.tgz",
-      "integrity": "sha512-SMIZpx6YL7Y9iKtgT/dl6vEF7eEAXLk+cR/oOmUWHu8vD/PXOtzlbqdPUTTn2/AL1pgzzBXxk6thM180UPo2eQ=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/util/-/util-0.16.3.tgz",
+      "integrity": "sha512-5GhpvXmumjcrPUdaFiQ3iILwG00RwXLlpfcygosTaBVuW0wK0i3aUXO9H1/6xrzWQbU5ILwtdz/FQ+0cioMj3g=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/v8": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/v8/-/v8-0.16.1.tgz",
-      "integrity": "sha512-F3s5EROkbXTM5qLdre7gWS3pSGimGWzEzDboiPiW0nYxmDH2PshiIhR/ZoKIcLzKPGBQPo1DB2LFCoDuawvj0g=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/v8/-/v8-0.16.3.tgz",
+      "integrity": "sha512-OVgzH/HzOONNFGeS/IWwB2nkgqiNC7tzVZU54ZKutG5LOiJmnwNJtCMZQ/2z2EiLzqwnwzKerHJopyWvGtsHOA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/vm": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/vm/-/vm-0.16.1.tgz",
-      "integrity": "sha512-/L8a8H/Rj1HRNsxLizlDhiIn0pzyAtHfl+dvaFN/DvW4OoJAw3Mnynl1eUsHgrUb/iWB/L1KPh/c1on6hXAl3Q=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/vm/-/vm-0.16.3.tgz",
+      "integrity": "sha512-3erWOi6bzzW7j4jaMOeX7hh0SEKHz1kqzyXCvXpuW+ysjPDy3TWbU4VGtFHLpGZ5fO/EHr5hhKV2DwsAHRYQ2Q=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/worker_threads": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/worker_threads/-/worker_threads-0.16.1.tgz",
-      "integrity": "sha512-mFR8XgVNh6DIOTRvQkfm/f8BjdR0wb6d5sIjMFGmr2eNNlOb2aTo7Gnq2nh1eCL/wN4oIdBdorzed8H0MuA9Kw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/worker_threads/-/worker_threads-0.16.3.tgz",
+      "integrity": "sha512-6003PbU+vCXI0UAbBGmnjG4izB0WO7qNCgjrK7JHc/uRYPyfqdDd50j50CGsMxkghh5sDMqx+r8OTVFnhzoLSw==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/message-channel": "^0.16.1",
-        "@gjsify/sab-native": "^0.16.1"
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/message-channel": "^0.16.3",
+        "@gjsify/sab-native": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/worker_threads/node_modules/@girs/gio-2.0": {
@@ -14846,17 +14846,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/worker_threads/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/worker_threads/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -14926,30 +14926,30 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/worker_threads/node_modules/@gjsify/message-channel": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/message-channel/-/message-channel-0.16.1.tgz",
-      "integrity": "sha512-Go2JeT3PWWZSe5T8AFewGoeT6d/xh1C8ZS1pTUTOdV9tPg8dw7PNpRugVUL8dtzquvxMXe340rO2W4sYgRxfbQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/message-channel/-/message-channel-0.16.3.tgz",
+      "integrity": "sha512-bAgM5CVhFKHcG/om2Rc7qYgHETjVP1vuShS+TwSv7Wa5n4VoRspxUyFRNvatjh8Zw0Rk8LABPmTzLs3ejWyrEw==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.16.1"
+        "@gjsify/dom-events": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/worker_threads/node_modules/@gjsify/message-channel/node_modules/@gjsify/dom-events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.1.tgz",
-      "integrity": "sha512-KQweggtpj4yvKH5QZsgKc5l2MC0Uj+sXy2FGfInQ/FvUbm5V0z/lHE8csPfRwpT0/If2FraINvdZjINmxSAIpg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.3.tgz",
+      "integrity": "sha512-CIxUMh3M9+I/V9LOmVdPw0ghJ0JG0DIdKJ17ltmI7FKwfdw37JmVmDvnPjuLgTxrH5arCieiD4FCg8CPdIC5uQ==",
       "dependencies": {
-        "@gjsify/dom-exception": "^0.16.1"
+        "@gjsify/dom-exception": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/worker_threads/node_modules/@gjsify/message-channel/node_modules/@gjsify/dom-events/node_modules/@gjsify/dom-exception": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.1.tgz",
-      "integrity": "sha512-vOg3Hb7KAqbh3bpEeasI41e6gasvihupzCJEfKVE81FsMbW88SRFWJ8+T049X21+G8jCWG19Jitaq3fLU1gE1g=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.3.tgz",
+      "integrity": "sha512-QbRlQp40v44iV0OmuNR3l01mftHFow/XDxWJt2HV64zbj/F+e7Lzt33w5zII3GVzXHoix+GBkJrazVBbtILmYA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/worker_threads/node_modules/@gjsify/sab-native": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/sab-native/-/sab-native-0.16.1.tgz",
-      "integrity": "sha512-gfJLc+MBNtVJ45cK1WeZRMdCqfFEY5gNFm+ecLHKpeWtBZlGAbChda+47aWH6241KbtnihK1rESj0kVm8uvUjw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/sab-native/-/sab-native-0.16.3.tgz",
+      "integrity": "sha512-jzfNIyn9ql9zl+MowxtcXG9K7I5pE7zqzxRaARlBJa83lPYhKpu3SbB5978Vzw2cquwqBchDPn57ViQdPsnFyQ==",
       "dependencies": {
         "@girs/gjs": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
@@ -14988,13 +14988,13 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/zlib": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/zlib/-/zlib-0.16.1.tgz",
-      "integrity": "sha512-6Cr510saN8bDIoWYmUEo9c04BNVtYYszYZRGkNK/OVqxiS3Z8GYC7ycGbQ/m28lOvB2gpXDoMejPAeS4xDI/eA==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/zlib/-/zlib-0.16.3.tgz",
+      "integrity": "sha512-2wbBm8EIgss6g82x5HwYkWQlIbXXKxOPLmzUJXX2gbtA20sBKYrcUVnMwIn5oyW/LrCISQFLieV0U9VNUuF9ww==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/stream": "^0.16.1"
+        "@gjsify/stream": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/zlib/node_modules/@girs/gio-2.0": {
@@ -15088,27 +15088,27 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/zlib/node_modules/@gjsify/stream": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.1.tgz",
-      "integrity": "sha512-KFm9H/6uLmmQoPtMAI9y9Or4aLip0qf24lQxU0wDTuIEcbMHpXN9vc4fHDrz5Qg03CffkfvHzh2jA8RDQQ9A6g==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.3.tgz",
+      "integrity": "sha512-jk2DfOKMdOPpU+Pjq5QE6qr9xVrQ3eXsepFtwLg/cGYAxG7xw/0/tI9BSinPVUF+PBEsFaX+Y6jz2HQokJsiuQ==",
       "dependencies": {
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/utils": "^0.16.1",
-        "@gjsify/web-streams": "^0.16.1"
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/utils": "^0.16.3",
+        "@gjsify/web-streams": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/zlib/node_modules/@gjsify/stream/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/zlib/node_modules/@gjsify/stream/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -15178,9 +15178,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/zlib/node_modules/@gjsify/stream/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -15250,17 +15250,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/zlib/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.1.tgz",
-      "integrity": "sha512-lBmnY/4IibT8igGmy/IrtcZQrQxZvW49cjwnIJ0Ty0GrpVgWg+8r2YE38iLj+BdVYMht8GFRPemWudRqJKN2kw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.3.tgz",
+      "integrity": "sha512-L+TQa0M2rNnvOQyvoB7ow73DEx5j8FFjKqNB0sqIRKbzYJiNXvHXngTcGjHlPKDHmBtwGL34hBBuUUzQzLZ9Gg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/node-polyfills/node_modules/@gjsify/zlib/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -15330,41 +15330,42 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/npm-registry": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/npm-registry/-/npm-registry-0.16.1.tgz",
-      "integrity": "sha512-PC2uFJ4bTMeE6zbmmxdhzuBHiHp1+cjSl/hab1DEfkp0+hlVEiprEvgtafg6QdcwPw2UI1sfMBwh2KKSK1divA=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/npm-registry/-/npm-registry-0.16.3.tgz",
+      "integrity": "sha512-AKYeZ1HgWPR8+Fl1oSmAG7IGuw8b+SGL/aK/ZEcfNA2BxBWo2Y2e448BHe9f/e1jKWZXFVO7YJ4R3jIBo7VoxA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/resolve-npm": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/resolve-npm/-/resolve-npm-0.16.1.tgz",
-      "integrity": "sha512-0PiEGEh+IeyZW0QZn5xUhJfhTZOg7kX9pS3QlygOnYibJBzYX4gGFKfirHcv5gTtJaAyMjzilo+mMdQ6r7GWQg=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/resolve-npm/-/resolve-npm-0.16.3.tgz",
+      "integrity": "sha512-nM+R8TXAJTcOqFSo32kb2tiLyKH4vjmQ19ZESOK1QVDw0K9SrteY+rGPB6zj5a0L/8S6y2EWk/CQZY712F2P1w=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/rolldown-plugin-gjsify": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-gjsify/-/rolldown-plugin-gjsify-0.16.1.tgz",
-      "integrity": "sha512-lUzFB1hX47lgmQXd1z+nU//iGktUJYYVu0eTBAPC9AOMVCRp8Fse5s6ndiLcgX0aZurlf7993G9Zx55eJGq0+g==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-gjsify/-/rolldown-plugin-gjsify-0.16.3.tgz",
+      "integrity": "sha512-3/Rkh4n1d1ggTwtBVIN6UdRCA4n/UhhedBv//HSR0d+h8PyZ8Kg8i+4CJi8MJp0wstJJkABtON1fDmKS9u2pRA==",
       "dependencies": {
-        "@gjsify/console": "^0.16.1",
-        "@gjsify/resolve-npm": "^0.16.1",
-        "@gjsify/rolldown-plugin-deepkit": "^0.16.1",
-        "@gjsify/rolldown-plugin-pnp": "^0.16.1",
-        "@gjsify/vite-plugin-blueprint": "^0.16.1",
+        "@gjsify/console": "^0.16.3",
+        "@gjsify/resolve-npm": "^0.16.3",
+        "@gjsify/rolldown-plugin-deepkit": "^0.16.3",
+        "@gjsify/rolldown-plugin-pnp": "^0.16.3",
+        "@gjsify/vite-plugin-blueprint": "^0.16.3",
         "@rollup/pluginutils": "^5.4.0",
         "acorn": "^8.17.0",
         "acorn-walk": "^8.3.5",
         "fast-glob": "^3.3.3",
-        "lightningcss": "^1.32.0"
+        "lightningcss": "^1.32.0",
+        "sass": "^1.101.0"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/rolldown-plugin-gjsify/node_modules/@gjsify/console": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/console/-/console-0.16.1.tgz",
-      "integrity": "sha512-QI4X3eWBc8+QL/cBQJi7tMxbKMKxudNJYnm/wk+iBvL2tSqMxWfSaxFW/ftntluTUQlm6N1e0x6/YZAshnMWgg=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/console/-/console-0.16.3.tgz",
+      "integrity": "sha512-6qDtkJM/LDiFu/CS4COGAnHY5xxD9Vbe9LbN60ZI4o2p31p68vmzFp7Jo70b1pQohl6KheYGpJnO5y0KFURa/Q=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/rolldown-plugin-gjsify/node_modules/@gjsify/resolve-npm": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/resolve-npm/-/resolve-npm-0.16.1.tgz",
-      "integrity": "sha512-0PiEGEh+IeyZW0QZn5xUhJfhTZOg7kX9pS3QlygOnYibJBzYX4gGFKfirHcv5gTtJaAyMjzilo+mMdQ6r7GWQg=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/resolve-npm/-/resolve-npm-0.16.3.tgz",
+      "integrity": "sha512-nM+R8TXAJTcOqFSo32kb2tiLyKH4vjmQ19ZESOK1QVDw0K9SrteY+rGPB6zj5a0L/8S6y2EWk/CQZY712F2P1w=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/rolldown-plugin-gjsify/node_modules/@gjsify/rolldown-plugin-deepkit": {
       "version": "0.14.0",
@@ -15376,62 +15377,62 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/rolldown-plugin-gjsify/node_modules/@gjsify/rolldown-plugin-pnp": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-pnp/-/rolldown-plugin-pnp-0.16.1.tgz",
-      "integrity": "sha512-SBPjXSYOzP7Mly4zoKHefzcGAbgDe2rTDdKBRjsBgquKsBcCvckFgKrviLBQpz19bGYJWtTrCgDT8xEA7+UECg=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-pnp/-/rolldown-plugin-pnp-0.16.3.tgz",
+      "integrity": "sha512-lwyRFAPaXG4coqiV5BM7bEh8i+/PruHt7gtkcZczx2K9TlhuwL5ffVDV8onh4f1d7RcwElWEILUbmM7bc8p4gg=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/rolldown-plugin-gjsify/node_modules/@gjsify/vite-plugin-blueprint": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/vite-plugin-blueprint/-/vite-plugin-blueprint-0.16.1.tgz",
-      "integrity": "sha512-xYyJjrQs4G00M8EK5plCM35U1pvWCyggruAMFJNZNASclGzDVY5/P5F5la1vpHsLRozO4rkypuR8GNaxok0m9Q==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/vite-plugin-blueprint/-/vite-plugin-blueprint-0.16.3.tgz",
+      "integrity": "sha512-8t2fbdYaRLIICdVlZlYAq+rSnxe3dTZCzn0Cxsn6Fsz9a61yjpFO/NiJhGh8zP+b45TDbpWzBxmvHOuKoULGPw==",
       "dependencies": {
         "execa": "^9.6.1",
         "minify-xml": "^4.5.2"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/rolldown-plugin-pnp": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-pnp/-/rolldown-plugin-pnp-0.16.1.tgz",
-      "integrity": "sha512-SBPjXSYOzP7Mly4zoKHefzcGAbgDe2rTDdKBRjsBgquKsBcCvckFgKrviLBQpz19bGYJWtTrCgDT8xEA7+UECg=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-pnp/-/rolldown-plugin-pnp-0.16.3.tgz",
+      "integrity": "sha512-lwyRFAPaXG4coqiV5BM7bEh8i+/PruHt7gtkcZczx2K9TlhuwL5ffVDV8onh4f1d7RcwElWEILUbmM7bc8p4gg=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/semver": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/semver/-/semver-0.16.1.tgz",
-      "integrity": "sha512-bppVPdQrKXN9T3wRG5yflTWbT+AtZVCkaUNCqqQPPORKVf57gZna1KNKG67GWgAueivtYcg4qciPRWO/KJQ/ZQ=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/semver/-/semver-0.16.3.tgz",
+      "integrity": "sha512-++geMXmfHhJFDGoC2OxYX8JSjE3VYEoM2jWHZyERovsK89H1VdRN4hhVt5A1ic2J6JtZhrth+QEPvbTr+pqGZQ=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tar": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/tar/-/tar-0.16.1.tgz",
-      "integrity": "sha512-G3Abgr462gEo4FvN3LE4ADPeeX6Y9LaBae2dD+rDLAqnPavfkF/qahivlswdeTVihFshUcsYcjiYZVuG/DJzkg=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/tar/-/tar-0.16.3.tgz",
+      "integrity": "sha512-6kCySZQmtaqTZv4kU+KlCTRknQ1HAZqKwz6DiJev9S/t+QayLCchiAswBFDx+s6Qo9U+0sHusxzsvzHpGGvmIA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/tsc/-/tsc-0.16.1.tgz",
-      "integrity": "sha512-m5awqkJmhc2Gc/UlzO3lUMVEuHsBM8h4MZ2ZjuLNEWhj+8iJx/EclrTcW8Yvh2rGSQs50gxORjchRDFd+1Mrmg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/tsc/-/tsc-0.16.3.tgz",
+      "integrity": "sha512-dWwS2XCSRJC8Tc+ZL5fUtZcV5RD6gtA5OwRADyd6PNt/vGmja4Xh0BK6Y1C5E2qyyechj6ap+fMVlRfwriS0zw==",
       "dependencies": {
-        "@gjsify/console": "^0.16.1",
-        "@gjsify/node-globals": "^0.16.1",
-        "@gjsify/web-globals": "^0.16.1"
+        "@gjsify/console": "^0.16.3",
+        "@gjsify/node-globals": "^0.16.3",
+        "@gjsify/web-globals": "^0.16.3"
       },
       "bin": {
         "gjsify-tsc": "./dist/tsc.gjs.mjs"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/console": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/console/-/console-0.16.1.tgz",
-      "integrity": "sha512-QI4X3eWBc8+QL/cBQJi7tMxbKMKxudNJYnm/wk+iBvL2tSqMxWfSaxFW/ftntluTUQlm6N1e0x6/YZAshnMWgg=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/console/-/console-0.16.3.tgz",
+      "integrity": "sha512-6qDtkJM/LDiFu/CS4COGAnHY5xxD9Vbe9LbN60ZI4o2p31p68vmzFp7Jo70b1pQohl6KheYGpJnO5y0KFURa/Q=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/node-globals": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/node-globals/-/node-globals-0.16.1.tgz",
-      "integrity": "sha512-cRmaWCOpJvXktli/j5LfH9MG3xyc2KsbjfHQplyKWc4T2Z+QuDZ/9fJRQa08W8r3JvQ1Lb+0MY97QakzrytDHA==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/node-globals/-/node-globals-0.16.3.tgz",
+      "integrity": "sha512-nTGUjCWgWlALor0j24A6YLXQeW1Q61Z3vlGQ+BT8Xf4G8n6ODJk56SRiP26cT0TYIiMwbVuW5CERFDW2AMC7tQ==",
       "dependencies": {
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/buffer": "^0.16.1",
-        "@gjsify/process": "^0.16.1",
-        "@gjsify/url": "^0.16.1",
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/buffer": "^0.16.3",
+        "@gjsify/process": "^0.16.3",
+        "@gjsify/url": "^0.16.3",
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/node-globals/node_modules/@girs/glib-2.0": {
@@ -15495,17 +15496,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/node-globals/node_modules/@gjsify/buffer": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.1.tgz",
-      "integrity": "sha512-dgapws5yErcmSb2EzKau/HOx7+oRmWnq25RIBv8ujmoq42hInIy1lrkpS0zqJtktqJEVO0yZi3JVedVkH/pzlw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.3.tgz",
+      "integrity": "sha512-dGzEBnIvm98W2Je8nWBH2k4ctHUerqZ8ABLr6QJ3JZHUaoYdQASQwVxsfzzxfkFu5/i/IEL/cNZVEKGet8sfeg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/node-globals/node_modules/@gjsify/buffer/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -15605,28 +15606,28 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/node-globals/node_modules/@gjsify/process": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/process/-/process-0.16.1.tgz",
-      "integrity": "sha512-XdaRFYRwrhltnw+rLjysdTDhC9HTNFwEpplIdCle1ROhe3/rqFpyUpKWnZ7vrgsbDTk66u0mLEZkper0LFdqYA==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/process/-/process-0.16.3.tgz",
+      "integrity": "sha512-/kdS5cL2I86Mzf/Mnovkspyf+IvxrGntKtLQGdUynRiL6Lduw8cRHVUHaB+NV0YpMSikY6oUcI8Bu8S8n6Ra6A==",
       "dependencies": {
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/string_decoder": "^0.16.1",
-        "@gjsify/terminal-native": "^0.16.1",
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/string_decoder": "^0.16.3",
+        "@gjsify/terminal-native": "^0.16.3",
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/node-globals/node_modules/@gjsify/process/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/node-globals/node_modules/@gjsify/process/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -15726,25 +15727,25 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/node-globals/node_modules/@gjsify/process/node_modules/@gjsify/string_decoder": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/string_decoder/-/string_decoder-0.16.1.tgz",
-      "integrity": "sha512-CJWri5Z/NSQn5jyav8Sd4EwOzIu5a7WVjo2c1FPWVVzftRAblBeRgI0d/V4/h+0ag3F19SatG9lgA6c205ZyxA==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/string_decoder/-/string_decoder-0.16.3.tgz",
+      "integrity": "sha512-6lnHN/rO7y+CLpiPO6wwBo/yqIuvI4OseAsokH0CecH2CWOU5k0xHwHLPOyFiyJptFd3vX2MvggzNZazx/wikw==",
       "dependencies": {
-        "@gjsify/buffer": "^0.16.1"
+        "@gjsify/buffer": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/node-globals/node_modules/@gjsify/process/node_modules/@gjsify/string_decoder/node_modules/@gjsify/buffer": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.1.tgz",
-      "integrity": "sha512-dgapws5yErcmSb2EzKau/HOx7+oRmWnq25RIBv8ujmoq42hInIy1lrkpS0zqJtktqJEVO0yZi3JVedVkH/pzlw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.3.tgz",
+      "integrity": "sha512-dGzEBnIvm98W2Je8nWBH2k4ctHUerqZ8ABLr6QJ3JZHUaoYdQASQwVxsfzzxfkFu5/i/IEL/cNZVEKGet8sfeg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/node-globals/node_modules/@gjsify/process/node_modules/@gjsify/string_decoder/node_modules/@gjsify/buffer/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -15844,9 +15845,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/node-globals/node_modules/@gjsify/process/node_modules/@gjsify/terminal-native": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native/-/terminal-native-0.16.1.tgz",
-      "integrity": "sha512-0lwVideLC0Kt226+OPjIhXZ/y6Uapn5hj0mmvFrH97LiHxJ9YOIkbaxk410CCfVaHHbpTUXJ/8EyR4Kb+WXlTQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native/-/terminal-native-0.16.3.tgz",
+      "integrity": "sha512-6E0TownC66KhgV/5cKgJ4G/lc7WrSm+FTURa0DiaJKbm8Kf2kpOYo295ZZ/2q0vNwU1+MYjn5hU8EcgsmhuPSw==",
       "dependencies": {
         "@girs/glib-2.0": "^4.1.0",
         "@girs/gobject-2.0": "^4.1.0"
@@ -15904,9 +15905,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/node-globals/node_modules/@gjsify/process/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -16006,17 +16007,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/node-globals/node_modules/@gjsify/url": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.16.1.tgz",
-      "integrity": "sha512-+enwAVUFMLMrca9spA2sjHcZJuHLWMSLqG5TuLRbpNcKAhnUxkAK1vERZ10rj8Y9Jo639Y+q0t9vqUxHR+sKmg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.16.3.tgz",
+      "integrity": "sha512-7oNt6TYBQCzKcf/7D8v2nBqw/D+a0rzuQ1J4jITqO/nHYQXGt4oV7RaLa7sC6EHNaoj0l9sUKPP3IMhm2+RNNw==",
       "dependencies": {
         "@girs/glib-2.0": "^4.1.0"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/node-globals/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -16116,58 +16117,58 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/web-globals": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-globals/-/web-globals-0.16.1.tgz",
-      "integrity": "sha512-fb3g4Y5/vRUA/NyLjiRrPj4N7UzwMVgqY/q47yW/OSPlI+Lps/TN2H/g//mHQScfgUBh3BOj1dUW+M/PIXgxyA==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-globals/-/web-globals-0.16.3.tgz",
+      "integrity": "sha512-Rt5DKEbiBLY/JzXC7AlQ+nnqJQw1ptri3wdFNKUape0I5KHJreCXflfkryQWpgVnYoPKMOjIRtfB0przPo4sOQ==",
       "dependencies": {
-        "@gjsify/abort-controller": "^0.16.1",
-        "@gjsify/buffer": "^0.16.1",
-        "@gjsify/compression-streams": "^0.16.1",
-        "@gjsify/dom-events": "^0.16.1",
-        "@gjsify/dom-exception": "^0.16.1",
-        "@gjsify/eventsource": "^0.16.1",
-        "@gjsify/formdata": "^0.16.1",
-        "@gjsify/gamepad": "^0.16.1",
-        "@gjsify/perf_hooks": "^0.16.1",
-        "@gjsify/url": "^0.16.1",
-        "@gjsify/web-streams": "^0.16.1",
-        "@gjsify/webaudio": "^0.16.1",
-        "@gjsify/webcrypto": "^0.16.1"
+        "@gjsify/abort-controller": "^0.16.3",
+        "@gjsify/buffer": "^0.16.3",
+        "@gjsify/compression-streams": "^0.16.3",
+        "@gjsify/dom-events": "^0.16.3",
+        "@gjsify/dom-exception": "^0.16.3",
+        "@gjsify/eventsource": "^0.16.3",
+        "@gjsify/formdata": "^0.16.3",
+        "@gjsify/gamepad": "^0.16.3",
+        "@gjsify/perf_hooks": "^0.16.3",
+        "@gjsify/url": "^0.16.3",
+        "@gjsify/web-streams": "^0.16.3",
+        "@gjsify/webaudio": "^0.16.3",
+        "@gjsify/webcrypto": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/web-globals/node_modules/@gjsify/abort-controller": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/abort-controller/-/abort-controller-0.16.1.tgz",
-      "integrity": "sha512-ZpQyLjxElwKIiDaSEsL05eBErw7Ph55lfj30wNNQ+qJwEB8YSRwCjE53NByEqrsIX5SjrrLrBZqeAdfVEceq1A==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/abort-controller/-/abort-controller-0.16.3.tgz",
+      "integrity": "sha512-bS7IUJFyPf7g1Q9++jH+yuIN/cNWsxtnBKQpmjcZYkCmIK0A91NnPY5b2F1y0kdK4wZqsBef0GMfv/CxB+FAkQ==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.16.1"
+        "@gjsify/dom-events": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/web-globals/node_modules/@gjsify/abort-controller/node_modules/@gjsify/dom-events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.1.tgz",
-      "integrity": "sha512-KQweggtpj4yvKH5QZsgKc5l2MC0Uj+sXy2FGfInQ/FvUbm5V0z/lHE8csPfRwpT0/If2FraINvdZjINmxSAIpg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.3.tgz",
+      "integrity": "sha512-CIxUMh3M9+I/V9LOmVdPw0ghJ0JG0DIdKJ17ltmI7FKwfdw37JmVmDvnPjuLgTxrH5arCieiD4FCg8CPdIC5uQ==",
       "dependencies": {
-        "@gjsify/dom-exception": "^0.16.1"
+        "@gjsify/dom-exception": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/web-globals/node_modules/@gjsify/abort-controller/node_modules/@gjsify/dom-events/node_modules/@gjsify/dom-exception": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.1.tgz",
-      "integrity": "sha512-vOg3Hb7KAqbh3bpEeasI41e6gasvihupzCJEfKVE81FsMbW88SRFWJ8+T049X21+G8jCWG19Jitaq3fLU1gE1g=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.3.tgz",
+      "integrity": "sha512-QbRlQp40v44iV0OmuNR3l01mftHFow/XDxWJt2HV64zbj/F+e7Lzt33w5zII3GVzXHoix+GBkJrazVBbtILmYA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/web-globals/node_modules/@gjsify/buffer": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.1.tgz",
-      "integrity": "sha512-dgapws5yErcmSb2EzKau/HOx7+oRmWnq25RIBv8ujmoq42hInIy1lrkpS0zqJtktqJEVO0yZi3JVedVkH/pzlw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.3.tgz",
+      "integrity": "sha512-dGzEBnIvm98W2Je8nWBH2k4ctHUerqZ8ABLr6QJ3JZHUaoYdQASQwVxsfzzxfkFu5/i/IEL/cNZVEKGet8sfeg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/web-globals/node_modules/@gjsify/buffer/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -16285,25 +16286,25 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/web-globals/node_modules/@gjsify/compression-streams": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/compression-streams/-/compression-streams-0.16.1.tgz",
-      "integrity": "sha512-8Z+aJWr4tHhOo2g14MWbQ5ig+Eu9+kPCOxhgFzXXP6V8hxh1UPexFfzHhuu7sKT5N4kjTiq/PwQPE2rOnaNSCw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/compression-streams/-/compression-streams-0.16.3.tgz",
+      "integrity": "sha512-U5HkaEDlyoDvsw3g5BfGX/7iHJi3CXrkfhQP+g6aVkkMRC68Btz6MvEHolW0huCyethvxFmc6M5MroMj3Eg8EQ==",
       "dependencies": {
-        "@gjsify/web-streams": "^0.16.1"
+        "@gjsify/web-streams": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/web-globals/node_modules/@gjsify/compression-streams/node_modules/@gjsify/web-streams": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.1.tgz",
-      "integrity": "sha512-lBmnY/4IibT8igGmy/IrtcZQrQxZvW49cjwnIJ0Ty0GrpVgWg+8r2YE38iLj+BdVYMht8GFRPemWudRqJKN2kw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.3.tgz",
+      "integrity": "sha512-L+TQa0M2rNnvOQyvoB7ow73DEx5j8FFjKqNB0sqIRKbzYJiNXvHXngTcGjHlPKDHmBtwGL34hBBuUUzQzLZ9Gg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/web-globals/node_modules/@gjsify/compression-streams/node_modules/@gjsify/web-streams/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -16421,57 +16422,57 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/web-globals/node_modules/@gjsify/dom-events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.1.tgz",
-      "integrity": "sha512-KQweggtpj4yvKH5QZsgKc5l2MC0Uj+sXy2FGfInQ/FvUbm5V0z/lHE8csPfRwpT0/If2FraINvdZjINmxSAIpg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.3.tgz",
+      "integrity": "sha512-CIxUMh3M9+I/V9LOmVdPw0ghJ0JG0DIdKJ17ltmI7FKwfdw37JmVmDvnPjuLgTxrH5arCieiD4FCg8CPdIC5uQ==",
       "dependencies": {
-        "@gjsify/dom-exception": "^0.16.1"
+        "@gjsify/dom-exception": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/web-globals/node_modules/@gjsify/dom-events/node_modules/@gjsify/dom-exception": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.1.tgz",
-      "integrity": "sha512-vOg3Hb7KAqbh3bpEeasI41e6gasvihupzCJEfKVE81FsMbW88SRFWJ8+T049X21+G8jCWG19Jitaq3fLU1gE1g=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.3.tgz",
+      "integrity": "sha512-QbRlQp40v44iV0OmuNR3l01mftHFow/XDxWJt2HV64zbj/F+e7Lzt33w5zII3GVzXHoix+GBkJrazVBbtILmYA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/web-globals/node_modules/@gjsify/dom-exception": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.1.tgz",
-      "integrity": "sha512-vOg3Hb7KAqbh3bpEeasI41e6gasvihupzCJEfKVE81FsMbW88SRFWJ8+T049X21+G8jCWG19Jitaq3fLU1gE1g=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.3.tgz",
+      "integrity": "sha512-QbRlQp40v44iV0OmuNR3l01mftHFow/XDxWJt2HV64zbj/F+e7Lzt33w5zII3GVzXHoix+GBkJrazVBbtILmYA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/web-globals/node_modules/@gjsify/eventsource": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/eventsource/-/eventsource-0.16.1.tgz",
-      "integrity": "sha512-djkt0P7NG5J1GTq1oSY+hKSr1f++emffWACkC4r5GJOCo+IiJt/i0JcNElTBqjmsY3zf1H7qgfF/2mnpLyuQ/Q==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/eventsource/-/eventsource-0.16.3.tgz",
+      "integrity": "sha512-pfxbtjErw/h0KPxx89+iYJtkAecZ5tzoYn9tB8M9reVJcEeE7DxnFRIAgjE6eFepSgrVVDaQHQrLeLtPIv2lFw==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.16.1",
-        "@gjsify/web-streams": "^0.16.1"
+        "@gjsify/dom-events": "^0.16.3",
+        "@gjsify/web-streams": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/web-globals/node_modules/@gjsify/eventsource/node_modules/@gjsify/dom-events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.1.tgz",
-      "integrity": "sha512-KQweggtpj4yvKH5QZsgKc5l2MC0Uj+sXy2FGfInQ/FvUbm5V0z/lHE8csPfRwpT0/If2FraINvdZjINmxSAIpg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.3.tgz",
+      "integrity": "sha512-CIxUMh3M9+I/V9LOmVdPw0ghJ0JG0DIdKJ17ltmI7FKwfdw37JmVmDvnPjuLgTxrH5arCieiD4FCg8CPdIC5uQ==",
       "dependencies": {
-        "@gjsify/dom-exception": "^0.16.1"
+        "@gjsify/dom-exception": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/web-globals/node_modules/@gjsify/eventsource/node_modules/@gjsify/dom-events/node_modules/@gjsify/dom-exception": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.1.tgz",
-      "integrity": "sha512-vOg3Hb7KAqbh3bpEeasI41e6gasvihupzCJEfKVE81FsMbW88SRFWJ8+T049X21+G8jCWG19Jitaq3fLU1gE1g=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.3.tgz",
+      "integrity": "sha512-QbRlQp40v44iV0OmuNR3l01mftHFow/XDxWJt2HV64zbj/F+e7Lzt33w5zII3GVzXHoix+GBkJrazVBbtILmYA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/web-globals/node_modules/@gjsify/eventsource/node_modules/@gjsify/web-streams": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.1.tgz",
-      "integrity": "sha512-lBmnY/4IibT8igGmy/IrtcZQrQxZvW49cjwnIJ0Ty0GrpVgWg+8r2YE38iLj+BdVYMht8GFRPemWudRqJKN2kw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.3.tgz",
+      "integrity": "sha512-L+TQa0M2rNnvOQyvoB7ow73DEx5j8FFjKqNB0sqIRKbzYJiNXvHXngTcGjHlPKDHmBtwGL34hBBuUUzQzLZ9Gg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/web-globals/node_modules/@gjsify/eventsource/node_modules/@gjsify/web-streams/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -16589,40 +16590,40 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/web-globals/node_modules/@gjsify/formdata": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/formdata/-/formdata-0.16.1.tgz",
-      "integrity": "sha512-9UJUf687+rMxewxvMVTSdhHbJgmJj0a1+X5W11I3EgEtQ76Lxbb8U1ZGe90rkrj2+9oteKjaLMNdthcQSkBzCQ=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/formdata/-/formdata-0.16.3.tgz",
+      "integrity": "sha512-p+Fao6I59Uh6wvZf+i0VSFLC7AzpcoGfFUU8GQ5Mv1V8NrbJ2FfqBOUprP31fT9DH0O3f7S7Az8Z8zJ/h/HIsA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/web-globals/node_modules/@gjsify/gamepad": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/gamepad/-/gamepad-0.16.1.tgz",
-      "integrity": "sha512-0B77qIU2D9Bn0IU4Kao/pwpSrJT9h9uDfDQZeJARkx4VJLvi8WPTbbT+AxUcCFpHpRfr/WOgDlKldz8XVN/5KA==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/gamepad/-/gamepad-0.16.3.tgz",
+      "integrity": "sha512-h1SLHT6ZwfD1BXHStxrBaQevy3kV6ueEpH5eLODDwLXgtwFg3lRgJxrIqRqqlLn81Sz9S/VTKCs6aYEcWYHTYw==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.16.1"
+        "@gjsify/dom-events": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/web-globals/node_modules/@gjsify/gamepad/node_modules/@gjsify/dom-events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.1.tgz",
-      "integrity": "sha512-KQweggtpj4yvKH5QZsgKc5l2MC0Uj+sXy2FGfInQ/FvUbm5V0z/lHE8csPfRwpT0/If2FraINvdZjINmxSAIpg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.3.tgz",
+      "integrity": "sha512-CIxUMh3M9+I/V9LOmVdPw0ghJ0JG0DIdKJ17ltmI7FKwfdw37JmVmDvnPjuLgTxrH5arCieiD4FCg8CPdIC5uQ==",
       "dependencies": {
-        "@gjsify/dom-exception": "^0.16.1"
+        "@gjsify/dom-exception": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/web-globals/node_modules/@gjsify/gamepad/node_modules/@gjsify/dom-events/node_modules/@gjsify/dom-exception": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.1.tgz",
-      "integrity": "sha512-vOg3Hb7KAqbh3bpEeasI41e6gasvihupzCJEfKVE81FsMbW88SRFWJ8+T049X21+G8jCWG19Jitaq3fLU1gE1g=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.3.tgz",
+      "integrity": "sha512-QbRlQp40v44iV0OmuNR3l01mftHFow/XDxWJt2HV64zbj/F+e7Lzt33w5zII3GVzXHoix+GBkJrazVBbtILmYA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/web-globals/node_modules/@gjsify/perf_hooks": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/perf_hooks/-/perf_hooks-0.16.1.tgz",
-      "integrity": "sha512-OpqLO1CgW48+vpgqXHIH1aCwyfyG6wnzIyCHA+4a3pZ3Mipbkwrv6yrie+7qi1kQyvRKi9m6JitmTnKBLN7pPg=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/perf_hooks/-/perf_hooks-0.16.3.tgz",
+      "integrity": "sha512-j/lLGVxEnI73jBlVxDmhwzKkOpTHEmlOEe+MYbvT9l0XeNoRTAM3OPjDh/HnI4EYdGRD5uciGBthL9BxDVjspQ=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/web-globals/node_modules/@gjsify/url": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.16.1.tgz",
-      "integrity": "sha512-+enwAVUFMLMrca9spA2sjHcZJuHLWMSLqG5TuLRbpNcKAhnUxkAK1vERZ10rj8Y9Jo639Y+q0t9vqUxHR+sKmg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.16.3.tgz",
+      "integrity": "sha512-7oNt6TYBQCzKcf/7D8v2nBqw/D+a0rzuQ1J4jITqO/nHYQXGt4oV7RaLa7sC6EHNaoj0l9sUKPP3IMhm2+RNNw==",
       "dependencies": {
         "@girs/glib-2.0": "^4.1.0"
       }
@@ -16688,17 +16689,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/web-globals/node_modules/@gjsify/web-streams": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.1.tgz",
-      "integrity": "sha512-lBmnY/4IibT8igGmy/IrtcZQrQxZvW49cjwnIJ0Ty0GrpVgWg+8r2YE38iLj+BdVYMht8GFRPemWudRqJKN2kw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.3.tgz",
+      "integrity": "sha512-L+TQa0M2rNnvOQyvoB7ow73DEx5j8FFjKqNB0sqIRKbzYJiNXvHXngTcGjHlPKDHmBtwGL34hBBuUUzQzLZ9Gg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/web-globals/node_modules/@gjsify/web-streams/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -16816,105 +16817,105 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/web-globals/node_modules/@gjsify/webaudio": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/webaudio/-/webaudio-0.16.1.tgz",
-      "integrity": "sha512-Xiky5oXuTQ+kArxJAZtItG+CEDyLxTDST2U/z1tL3Px25H7PN+d8IBGGbU4MsSwHByJG2ku+kv8Lsa9zTdWOaA==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/webaudio/-/webaudio-0.16.3.tgz",
+      "integrity": "sha512-JDvvDPyrpgAA3bXITK1XGUos1qOaMjBIX1lwxwTN8Oq1FHAmTZ7F2TSeMnTnEnpv5yPQL4Ot/HDbiyVWXBtGog==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.16.1"
+        "@gjsify/dom-events": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/web-globals/node_modules/@gjsify/webaudio/node_modules/@gjsify/dom-events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.1.tgz",
-      "integrity": "sha512-KQweggtpj4yvKH5QZsgKc5l2MC0Uj+sXy2FGfInQ/FvUbm5V0z/lHE8csPfRwpT0/If2FraINvdZjINmxSAIpg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.3.tgz",
+      "integrity": "sha512-CIxUMh3M9+I/V9LOmVdPw0ghJ0JG0DIdKJ17ltmI7FKwfdw37JmVmDvnPjuLgTxrH5arCieiD4FCg8CPdIC5uQ==",
       "dependencies": {
-        "@gjsify/dom-exception": "^0.16.1"
+        "@gjsify/dom-exception": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/web-globals/node_modules/@gjsify/webaudio/node_modules/@gjsify/dom-events/node_modules/@gjsify/dom-exception": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.1.tgz",
-      "integrity": "sha512-vOg3Hb7KAqbh3bpEeasI41e6gasvihupzCJEfKVE81FsMbW88SRFWJ8+T049X21+G8jCWG19Jitaq3fLU1gE1g=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.3.tgz",
+      "integrity": "sha512-QbRlQp40v44iV0OmuNR3l01mftHFow/XDxWJt2HV64zbj/F+e7Lzt33w5zII3GVzXHoix+GBkJrazVBbtILmYA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/web-globals/node_modules/@gjsify/webcrypto": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/webcrypto/-/webcrypto-0.16.1.tgz",
-      "integrity": "sha512-Gv1sZ23mEUjV1pxEfd5AGpCUVOVMNt6dfdKGBZyQwyCM4yOw824awfi0xjBDl0H3g7C60v+sHCgH31oR+nRYnQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/webcrypto/-/webcrypto-0.16.3.tgz",
+      "integrity": "sha512-g1MvSs8uRg0l9JVxa5JT7xiZ4Z9I2/QM1RTKnBodGZSmnbFk9KmyMKHu5tPhXthJjlNFpctMbOV4ISiJy0l14w==",
       "dependencies": {
-        "@gjsify/dom-exception": "^0.16.1"
+        "@gjsify/dom-exception": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/tsc/node_modules/@gjsify/web-globals/node_modules/@gjsify/webcrypto/node_modules/@gjsify/dom-exception": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.1.tgz",
-      "integrity": "sha512-vOg3Hb7KAqbh3bpEeasI41e6gasvihupzCJEfKVE81FsMbW88SRFWJ8+T049X21+G8jCWG19Jitaq3fLU1gE1g=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.3.tgz",
+      "integrity": "sha512-QbRlQp40v44iV0OmuNR3l01mftHFow/XDxWJt2HV64zbj/F+e7Lzt33w5zII3GVzXHoix+GBkJrazVBbtILmYA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-polyfills/-/web-polyfills-0.16.1.tgz",
-      "integrity": "sha512-5mvpUVD4qjxV9vTyThLQRaf9wPDaLqsCXhFGwMcgyO0536U8JcMEkp6f1+GB3mXA47Xe6FxgnhbkIy6UlRNzfg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-polyfills/-/web-polyfills-0.16.3.tgz",
+      "integrity": "sha512-SE3bhU2LfS6XMdLUH9YCKTBUmia/49F4/zK9lnT80P8jSfsG6zZu1XmTl8wEGiASIw0G2txYbtlXiU4RPrw56w==",
       "dependencies": {
-        "@gjsify/abort-controller": "^0.16.1",
-        "@gjsify/compression-streams": "^0.16.1",
-        "@gjsify/dom-events": "^0.16.1",
-        "@gjsify/dom-exception": "^0.16.1",
-        "@gjsify/domparser": "^0.16.1",
-        "@gjsify/eventsource": "^0.16.1",
-        "@gjsify/fetch": "^0.16.1",
-        "@gjsify/formdata": "^0.16.1",
-        "@gjsify/gamepad": "^0.16.1",
-        "@gjsify/message-channel": "^0.16.1",
-        "@gjsify/web-globals": "^0.16.1",
-        "@gjsify/web-streams": "^0.16.1",
-        "@gjsify/webassembly": "^0.16.1",
-        "@gjsify/webaudio": "^0.16.1",
-        "@gjsify/webcrypto": "^0.16.1",
-        "@gjsify/websocket": "^0.16.1",
-        "@gjsify/webstorage": "^0.16.1",
-        "@gjsify/xmlhttprequest": "^0.16.1"
+        "@gjsify/abort-controller": "^0.16.3",
+        "@gjsify/compression-streams": "^0.16.3",
+        "@gjsify/dom-events": "^0.16.3",
+        "@gjsify/dom-exception": "^0.16.3",
+        "@gjsify/domparser": "^0.16.3",
+        "@gjsify/eventsource": "^0.16.3",
+        "@gjsify/fetch": "^0.16.3",
+        "@gjsify/formdata": "^0.16.3",
+        "@gjsify/gamepad": "^0.16.3",
+        "@gjsify/message-channel": "^0.16.3",
+        "@gjsify/web-globals": "^0.16.3",
+        "@gjsify/web-streams": "^0.16.3",
+        "@gjsify/webassembly": "^0.16.3",
+        "@gjsify/webaudio": "^0.16.3",
+        "@gjsify/webcrypto": "^0.16.3",
+        "@gjsify/websocket": "^0.16.3",
+        "@gjsify/webstorage": "^0.16.3",
+        "@gjsify/xmlhttprequest": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/abort-controller": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/abort-controller/-/abort-controller-0.16.1.tgz",
-      "integrity": "sha512-ZpQyLjxElwKIiDaSEsL05eBErw7Ph55lfj30wNNQ+qJwEB8YSRwCjE53NByEqrsIX5SjrrLrBZqeAdfVEceq1A==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/abort-controller/-/abort-controller-0.16.3.tgz",
+      "integrity": "sha512-bS7IUJFyPf7g1Q9++jH+yuIN/cNWsxtnBKQpmjcZYkCmIK0A91NnPY5b2F1y0kdK4wZqsBef0GMfv/CxB+FAkQ==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.16.1"
+        "@gjsify/dom-events": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/abort-controller/node_modules/@gjsify/dom-events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.1.tgz",
-      "integrity": "sha512-KQweggtpj4yvKH5QZsgKc5l2MC0Uj+sXy2FGfInQ/FvUbm5V0z/lHE8csPfRwpT0/If2FraINvdZjINmxSAIpg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.3.tgz",
+      "integrity": "sha512-CIxUMh3M9+I/V9LOmVdPw0ghJ0JG0DIdKJ17ltmI7FKwfdw37JmVmDvnPjuLgTxrH5arCieiD4FCg8CPdIC5uQ==",
       "dependencies": {
-        "@gjsify/dom-exception": "^0.16.1"
+        "@gjsify/dom-exception": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/abort-controller/node_modules/@gjsify/dom-events/node_modules/@gjsify/dom-exception": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.1.tgz",
-      "integrity": "sha512-vOg3Hb7KAqbh3bpEeasI41e6gasvihupzCJEfKVE81FsMbW88SRFWJ8+T049X21+G8jCWG19Jitaq3fLU1gE1g=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.3.tgz",
+      "integrity": "sha512-QbRlQp40v44iV0OmuNR3l01mftHFow/XDxWJt2HV64zbj/F+e7Lzt33w5zII3GVzXHoix+GBkJrazVBbtILmYA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/compression-streams": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/compression-streams/-/compression-streams-0.16.1.tgz",
-      "integrity": "sha512-8Z+aJWr4tHhOo2g14MWbQ5ig+Eu9+kPCOxhgFzXXP6V8hxh1UPexFfzHhuu7sKT5N4kjTiq/PwQPE2rOnaNSCw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/compression-streams/-/compression-streams-0.16.3.tgz",
+      "integrity": "sha512-U5HkaEDlyoDvsw3g5BfGX/7iHJi3CXrkfhQP+g6aVkkMRC68Btz6MvEHolW0huCyethvxFmc6M5MroMj3Eg8EQ==",
       "dependencies": {
-        "@gjsify/web-streams": "^0.16.1"
+        "@gjsify/web-streams": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/compression-streams/node_modules/@gjsify/web-streams": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.1.tgz",
-      "integrity": "sha512-lBmnY/4IibT8igGmy/IrtcZQrQxZvW49cjwnIJ0Ty0GrpVgWg+8r2YE38iLj+BdVYMht8GFRPemWudRqJKN2kw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.3.tgz",
+      "integrity": "sha512-L+TQa0M2rNnvOQyvoB7ow73DEx5j8FFjKqNB0sqIRKbzYJiNXvHXngTcGjHlPKDHmBtwGL34hBBuUUzQzLZ9Gg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/compression-streams/node_modules/@gjsify/web-streams/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -17032,62 +17033,62 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/dom-events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.1.tgz",
-      "integrity": "sha512-KQweggtpj4yvKH5QZsgKc5l2MC0Uj+sXy2FGfInQ/FvUbm5V0z/lHE8csPfRwpT0/If2FraINvdZjINmxSAIpg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.3.tgz",
+      "integrity": "sha512-CIxUMh3M9+I/V9LOmVdPw0ghJ0JG0DIdKJ17ltmI7FKwfdw37JmVmDvnPjuLgTxrH5arCieiD4FCg8CPdIC5uQ==",
       "dependencies": {
-        "@gjsify/dom-exception": "^0.16.1"
+        "@gjsify/dom-exception": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/dom-events/node_modules/@gjsify/dom-exception": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.1.tgz",
-      "integrity": "sha512-vOg3Hb7KAqbh3bpEeasI41e6gasvihupzCJEfKVE81FsMbW88SRFWJ8+T049X21+G8jCWG19Jitaq3fLU1gE1g=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.3.tgz",
+      "integrity": "sha512-QbRlQp40v44iV0OmuNR3l01mftHFow/XDxWJt2HV64zbj/F+e7Lzt33w5zII3GVzXHoix+GBkJrazVBbtILmYA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/dom-exception": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.1.tgz",
-      "integrity": "sha512-vOg3Hb7KAqbh3bpEeasI41e6gasvihupzCJEfKVE81FsMbW88SRFWJ8+T049X21+G8jCWG19Jitaq3fLU1gE1g=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.3.tgz",
+      "integrity": "sha512-QbRlQp40v44iV0OmuNR3l01mftHFow/XDxWJt2HV64zbj/F+e7Lzt33w5zII3GVzXHoix+GBkJrazVBbtILmYA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/domparser": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/domparser/-/domparser-0.16.1.tgz",
-      "integrity": "sha512-s5belqmmlvVs89DV4/GVbqVHw05P8YvdnjsdZX1hhPyd/rfU+mkNBJ8a2G7pYnMHw3g10JA++BokVIn8o+xlKQ=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/domparser/-/domparser-0.16.3.tgz",
+      "integrity": "sha512-1eW8U4ZQlaFvH1isvdl5WFg43+SLCrWLuil17OcNsm7QTdDzk8N+2pml74oK8F7PbLi76jHXrhpIZ/Ck7HShQA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/eventsource": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/eventsource/-/eventsource-0.16.1.tgz",
-      "integrity": "sha512-djkt0P7NG5J1GTq1oSY+hKSr1f++emffWACkC4r5GJOCo+IiJt/i0JcNElTBqjmsY3zf1H7qgfF/2mnpLyuQ/Q==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/eventsource/-/eventsource-0.16.3.tgz",
+      "integrity": "sha512-pfxbtjErw/h0KPxx89+iYJtkAecZ5tzoYn9tB8M9reVJcEeE7DxnFRIAgjE6eFepSgrVVDaQHQrLeLtPIv2lFw==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.16.1",
-        "@gjsify/web-streams": "^0.16.1"
+        "@gjsify/dom-events": "^0.16.3",
+        "@gjsify/web-streams": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/eventsource/node_modules/@gjsify/dom-events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.1.tgz",
-      "integrity": "sha512-KQweggtpj4yvKH5QZsgKc5l2MC0Uj+sXy2FGfInQ/FvUbm5V0z/lHE8csPfRwpT0/If2FraINvdZjINmxSAIpg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.3.tgz",
+      "integrity": "sha512-CIxUMh3M9+I/V9LOmVdPw0ghJ0JG0DIdKJ17ltmI7FKwfdw37JmVmDvnPjuLgTxrH5arCieiD4FCg8CPdIC5uQ==",
       "dependencies": {
-        "@gjsify/dom-exception": "^0.16.1"
+        "@gjsify/dom-exception": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/eventsource/node_modules/@gjsify/dom-events/node_modules/@gjsify/dom-exception": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.1.tgz",
-      "integrity": "sha512-vOg3Hb7KAqbh3bpEeasI41e6gasvihupzCJEfKVE81FsMbW88SRFWJ8+T049X21+G8jCWG19Jitaq3fLU1gE1g=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.3.tgz",
+      "integrity": "sha512-QbRlQp40v44iV0OmuNR3l01mftHFow/XDxWJt2HV64zbj/F+e7Lzt33w5zII3GVzXHoix+GBkJrazVBbtILmYA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/eventsource/node_modules/@gjsify/web-streams": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.1.tgz",
-      "integrity": "sha512-lBmnY/4IibT8igGmy/IrtcZQrQxZvW49cjwnIJ0Ty0GrpVgWg+8r2YE38iLj+BdVYMht8GFRPemWudRqJKN2kw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.3.tgz",
+      "integrity": "sha512-L+TQa0M2rNnvOQyvoB7ow73DEx5j8FFjKqNB0sqIRKbzYJiNXvHXngTcGjHlPKDHmBtwGL34hBBuUUzQzLZ9Gg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/eventsource/node_modules/@gjsify/web-streams/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -17205,18 +17206,18 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/fetch": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/fetch/-/fetch-0.16.1.tgz",
-      "integrity": "sha512-MavUbh5kJzRSQGVdriqKvvvRTchicy19o8yKKAI9p5CWR2/98AS38nmGqOtco0P0VumeBPbbU3QRMejZv6tGBA==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/fetch/-/fetch-0.16.3.tgz",
+      "integrity": "sha512-eAsOvuuctoMeGx7F35sMeP1siB8fU7mxMr7deJBnFQAZm8k/oEALhassb5M6tMub2voK3ECNPv/2QuthC7mOeA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/gjs": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
         "@girs/soup-3.0": "^4.1.0",
-        "@gjsify/formdata": "^0.16.1",
-        "@gjsify/http": "^0.16.1",
-        "@gjsify/url": "^0.16.1",
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/formdata": "^0.16.3",
+        "@gjsify/http": "^0.16.3",
+        "@gjsify/url": "^0.16.3",
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/fetch/node_modules/@girs/gio-2.0": {
@@ -17329,39 +17330,39 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/fetch/node_modules/@gjsify/formdata": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/formdata/-/formdata-0.16.1.tgz",
-      "integrity": "sha512-9UJUf687+rMxewxvMVTSdhHbJgmJj0a1+X5W11I3EgEtQ76Lxbb8U1ZGe90rkrj2+9oteKjaLMNdthcQSkBzCQ=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/formdata/-/formdata-0.16.3.tgz",
+      "integrity": "sha512-p+Fao6I59Uh6wvZf+i0VSFLC7AzpcoGfFUU8GQ5Mv1V8NrbJ2FfqBOUprP31fT9DH0O3f7S7Az8Z8zJ/h/HIsA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/fetch/node_modules/@gjsify/http": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/http/-/http-0.16.1.tgz",
-      "integrity": "sha512-LoMdpA5z5nhEH+Rbn5LOuNUHQ/knzcQMA2WvxFMTm1iyWrfgYdaDiDoMMHcOq52QnF7rR79c2KA0ehyOntY1Rg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/http/-/http-0.16.3.tgz",
+      "integrity": "sha512-SLdgQz6NhtH1HG8BfoBN9ozf4XkTkkW92YT/NJjvND6uk3oL9C4WvAmv/YEttaHjHfWoaNog1R06Rg5/UHUtEg==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
         "@girs/soup-3.0": "^4.1.0",
-        "@gjsify/buffer": "^0.16.1",
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/http-soup-bridge": "^0.16.1",
-        "@gjsify/net": "^0.16.1",
-        "@gjsify/stream": "^0.16.1",
-        "@gjsify/url": "^0.16.1",
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/buffer": "^0.16.3",
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/http-soup-bridge": "^0.16.3",
+        "@gjsify/net": "^0.16.3",
+        "@gjsify/stream": "^0.16.3",
+        "@gjsify/url": "^0.16.3",
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/buffer": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.1.tgz",
-      "integrity": "sha512-dgapws5yErcmSb2EzKau/HOx7+oRmWnq25RIBv8ujmoq42hInIy1lrkpS0zqJtktqJEVO0yZi3JVedVkH/pzlw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.3.tgz",
+      "integrity": "sha512-dGzEBnIvm98W2Je8nWBH2k4ctHUerqZ8ABLr6QJ3JZHUaoYdQASQwVxsfzzxfkFu5/i/IEL/cNZVEKGet8sfeg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/buffer/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -17401,17 +17402,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -17451,9 +17452,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/http-soup-bridge": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge/-/http-soup-bridge-0.16.1.tgz",
-      "integrity": "sha512-WRWNT6LmkNaacSMo+R2x2QFVqld9H2grjM6RnEG2rvCb3M9horIsuM7kGNjlUpWor3vb7KQ8KVJ8BOtoo+MXoQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge/-/http-soup-bridge-0.16.3.tgz",
+      "integrity": "sha512-PUf2QVNAZDPJuRsEdwgxs4/bV+iP0SSlcterP0benh9xUjFWB6RDuv3rsJWtaNdnleD+lky9zGpYJbG+MpkhqA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/gjs": "^4.1.0",
@@ -17472,30 +17473,30 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/net": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/net/-/net-0.16.1.tgz",
-      "integrity": "sha512-fMFXtl0KAt+IEUwU+TuiB70kyYi7J8xu4MURDo9aXI1yzIblCXyMxRw/fGuRECLpsAeJONl/6ckIlPrst/Hf9g==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/net/-/net-0.16.3.tgz",
+      "integrity": "sha512-mFVIDc38GAPz1TKNE5zRP0SacVMAucaC/YvNQtpR6ISs/EicfWvgWt+XDckYgizKSmL2dJlYkGKnlwUbxZ9jtg==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/buffer": "^0.16.1",
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/stream": "^0.16.1",
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/buffer": "^0.16.3",
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/stream": "^0.16.3",
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/buffer": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.1.tgz",
-      "integrity": "sha512-dgapws5yErcmSb2EzKau/HOx7+oRmWnq25RIBv8ujmoq42hInIy1lrkpS0zqJtktqJEVO0yZi3JVedVkH/pzlw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.3.tgz",
+      "integrity": "sha512-dGzEBnIvm98W2Je8nWBH2k4ctHUerqZ8ABLr6QJ3JZHUaoYdQASQwVxsfzzxfkFu5/i/IEL/cNZVEKGet8sfeg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/buffer/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -17535,17 +17536,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -17585,27 +17586,27 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/stream": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.1.tgz",
-      "integrity": "sha512-KFm9H/6uLmmQoPtMAI9y9Or4aLip0qf24lQxU0wDTuIEcbMHpXN9vc4fHDrz5Qg03CffkfvHzh2jA8RDQQ9A6g==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.3.tgz",
+      "integrity": "sha512-jk2DfOKMdOPpU+Pjq5QE6qr9xVrQ3eXsepFtwLg/cGYAxG7xw/0/tI9BSinPVUF+PBEsFaX+Y6jz2HQokJsiuQ==",
       "dependencies": {
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/utils": "^0.16.1",
-        "@gjsify/web-streams": "^0.16.1"
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/utils": "^0.16.3",
+        "@gjsify/web-streams": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -17645,9 +17646,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -17687,17 +17688,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.1.tgz",
-      "integrity": "sha512-lBmnY/4IibT8igGmy/IrtcZQrQxZvW49cjwnIJ0Ty0GrpVgWg+8r2YE38iLj+BdVYMht8GFRPemWudRqJKN2kw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.3.tgz",
+      "integrity": "sha512-L+TQa0M2rNnvOQyvoB7ow73DEx5j8FFjKqNB0sqIRKbzYJiNXvHXngTcGjHlPKDHmBtwGL34hBBuUUzQzLZ9Gg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -17737,9 +17738,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -17779,27 +17780,27 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/stream": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.1.tgz",
-      "integrity": "sha512-KFm9H/6uLmmQoPtMAI9y9Or4aLip0qf24lQxU0wDTuIEcbMHpXN9vc4fHDrz5Qg03CffkfvHzh2jA8RDQQ9A6g==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.3.tgz",
+      "integrity": "sha512-jk2DfOKMdOPpU+Pjq5QE6qr9xVrQ3eXsepFtwLg/cGYAxG7xw/0/tI9BSinPVUF+PBEsFaX+Y6jz2HQokJsiuQ==",
       "dependencies": {
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/utils": "^0.16.1",
-        "@gjsify/web-streams": "^0.16.1"
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/utils": "^0.16.3",
+        "@gjsify/web-streams": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/stream/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/stream/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -17839,9 +17840,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/stream/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -17881,17 +17882,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.1.tgz",
-      "integrity": "sha512-lBmnY/4IibT8igGmy/IrtcZQrQxZvW49cjwnIJ0Ty0GrpVgWg+8r2YE38iLj+BdVYMht8GFRPemWudRqJKN2kw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.3.tgz",
+      "integrity": "sha512-L+TQa0M2rNnvOQyvoB7ow73DEx5j8FFjKqNB0sqIRKbzYJiNXvHXngTcGjHlPKDHmBtwGL34hBBuUUzQzLZ9Gg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -17931,17 +17932,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/url": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.16.1.tgz",
-      "integrity": "sha512-+enwAVUFMLMrca9spA2sjHcZJuHLWMSLqG5TuLRbpNcKAhnUxkAK1vERZ10rj8Y9Jo639Y+q0t9vqUxHR+sKmg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.16.3.tgz",
+      "integrity": "sha512-7oNt6TYBQCzKcf/7D8v2nBqw/D+a0rzuQ1J4jITqO/nHYQXGt4oV7RaLa7sC6EHNaoj0l9sUKPP3IMhm2+RNNw==",
       "dependencies": {
         "@girs/glib-2.0": "^4.1.0"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -17981,17 +17982,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/fetch/node_modules/@gjsify/url": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.16.1.tgz",
-      "integrity": "sha512-+enwAVUFMLMrca9spA2sjHcZJuHLWMSLqG5TuLRbpNcKAhnUxkAK1vERZ10rj8Y9Jo639Y+q0t9vqUxHR+sKmg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.16.3.tgz",
+      "integrity": "sha512-7oNt6TYBQCzKcf/7D8v2nBqw/D+a0rzuQ1J4jITqO/nHYQXGt4oV7RaLa7sC6EHNaoj0l9sUKPP3IMhm2+RNNw==",
       "dependencies": {
         "@girs/glib-2.0": "^4.1.0"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/fetch/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -18031,105 +18032,105 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/formdata": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/formdata/-/formdata-0.16.1.tgz",
-      "integrity": "sha512-9UJUf687+rMxewxvMVTSdhHbJgmJj0a1+X5W11I3EgEtQ76Lxbb8U1ZGe90rkrj2+9oteKjaLMNdthcQSkBzCQ=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/formdata/-/formdata-0.16.3.tgz",
+      "integrity": "sha512-p+Fao6I59Uh6wvZf+i0VSFLC7AzpcoGfFUU8GQ5Mv1V8NrbJ2FfqBOUprP31fT9DH0O3f7S7Az8Z8zJ/h/HIsA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/gamepad": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/gamepad/-/gamepad-0.16.1.tgz",
-      "integrity": "sha512-0B77qIU2D9Bn0IU4Kao/pwpSrJT9h9uDfDQZeJARkx4VJLvi8WPTbbT+AxUcCFpHpRfr/WOgDlKldz8XVN/5KA==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/gamepad/-/gamepad-0.16.3.tgz",
+      "integrity": "sha512-h1SLHT6ZwfD1BXHStxrBaQevy3kV6ueEpH5eLODDwLXgtwFg3lRgJxrIqRqqlLn81Sz9S/VTKCs6aYEcWYHTYw==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.16.1"
+        "@gjsify/dom-events": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/gamepad/node_modules/@gjsify/dom-events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.1.tgz",
-      "integrity": "sha512-KQweggtpj4yvKH5QZsgKc5l2MC0Uj+sXy2FGfInQ/FvUbm5V0z/lHE8csPfRwpT0/If2FraINvdZjINmxSAIpg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.3.tgz",
+      "integrity": "sha512-CIxUMh3M9+I/V9LOmVdPw0ghJ0JG0DIdKJ17ltmI7FKwfdw37JmVmDvnPjuLgTxrH5arCieiD4FCg8CPdIC5uQ==",
       "dependencies": {
-        "@gjsify/dom-exception": "^0.16.1"
+        "@gjsify/dom-exception": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/gamepad/node_modules/@gjsify/dom-events/node_modules/@gjsify/dom-exception": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.1.tgz",
-      "integrity": "sha512-vOg3Hb7KAqbh3bpEeasI41e6gasvihupzCJEfKVE81FsMbW88SRFWJ8+T049X21+G8jCWG19Jitaq3fLU1gE1g=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.3.tgz",
+      "integrity": "sha512-QbRlQp40v44iV0OmuNR3l01mftHFow/XDxWJt2HV64zbj/F+e7Lzt33w5zII3GVzXHoix+GBkJrazVBbtILmYA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/message-channel": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/message-channel/-/message-channel-0.16.1.tgz",
-      "integrity": "sha512-Go2JeT3PWWZSe5T8AFewGoeT6d/xh1C8ZS1pTUTOdV9tPg8dw7PNpRugVUL8dtzquvxMXe340rO2W4sYgRxfbQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/message-channel/-/message-channel-0.16.3.tgz",
+      "integrity": "sha512-bAgM5CVhFKHcG/om2Rc7qYgHETjVP1vuShS+TwSv7Wa5n4VoRspxUyFRNvatjh8Zw0Rk8LABPmTzLs3ejWyrEw==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.16.1"
+        "@gjsify/dom-events": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/message-channel/node_modules/@gjsify/dom-events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.1.tgz",
-      "integrity": "sha512-KQweggtpj4yvKH5QZsgKc5l2MC0Uj+sXy2FGfInQ/FvUbm5V0z/lHE8csPfRwpT0/If2FraINvdZjINmxSAIpg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.3.tgz",
+      "integrity": "sha512-CIxUMh3M9+I/V9LOmVdPw0ghJ0JG0DIdKJ17ltmI7FKwfdw37JmVmDvnPjuLgTxrH5arCieiD4FCg8CPdIC5uQ==",
       "dependencies": {
-        "@gjsify/dom-exception": "^0.16.1"
+        "@gjsify/dom-exception": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/message-channel/node_modules/@gjsify/dom-events/node_modules/@gjsify/dom-exception": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.1.tgz",
-      "integrity": "sha512-vOg3Hb7KAqbh3bpEeasI41e6gasvihupzCJEfKVE81FsMbW88SRFWJ8+T049X21+G8jCWG19Jitaq3fLU1gE1g=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.3.tgz",
+      "integrity": "sha512-QbRlQp40v44iV0OmuNR3l01mftHFow/XDxWJt2HV64zbj/F+e7Lzt33w5zII3GVzXHoix+GBkJrazVBbtILmYA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/web-globals": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-globals/-/web-globals-0.16.1.tgz",
-      "integrity": "sha512-fb3g4Y5/vRUA/NyLjiRrPj4N7UzwMVgqY/q47yW/OSPlI+Lps/TN2H/g//mHQScfgUBh3BOj1dUW+M/PIXgxyA==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-globals/-/web-globals-0.16.3.tgz",
+      "integrity": "sha512-Rt5DKEbiBLY/JzXC7AlQ+nnqJQw1ptri3wdFNKUape0I5KHJreCXflfkryQWpgVnYoPKMOjIRtfB0przPo4sOQ==",
       "dependencies": {
-        "@gjsify/abort-controller": "^0.16.1",
-        "@gjsify/buffer": "^0.16.1",
-        "@gjsify/compression-streams": "^0.16.1",
-        "@gjsify/dom-events": "^0.16.1",
-        "@gjsify/dom-exception": "^0.16.1",
-        "@gjsify/eventsource": "^0.16.1",
-        "@gjsify/formdata": "^0.16.1",
-        "@gjsify/gamepad": "^0.16.1",
-        "@gjsify/perf_hooks": "^0.16.1",
-        "@gjsify/url": "^0.16.1",
-        "@gjsify/web-streams": "^0.16.1",
-        "@gjsify/webaudio": "^0.16.1",
-        "@gjsify/webcrypto": "^0.16.1"
+        "@gjsify/abort-controller": "^0.16.3",
+        "@gjsify/buffer": "^0.16.3",
+        "@gjsify/compression-streams": "^0.16.3",
+        "@gjsify/dom-events": "^0.16.3",
+        "@gjsify/dom-exception": "^0.16.3",
+        "@gjsify/eventsource": "^0.16.3",
+        "@gjsify/formdata": "^0.16.3",
+        "@gjsify/gamepad": "^0.16.3",
+        "@gjsify/perf_hooks": "^0.16.3",
+        "@gjsify/url": "^0.16.3",
+        "@gjsify/web-streams": "^0.16.3",
+        "@gjsify/webaudio": "^0.16.3",
+        "@gjsify/webcrypto": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/web-globals/node_modules/@gjsify/abort-controller": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/abort-controller/-/abort-controller-0.16.1.tgz",
-      "integrity": "sha512-ZpQyLjxElwKIiDaSEsL05eBErw7Ph55lfj30wNNQ+qJwEB8YSRwCjE53NByEqrsIX5SjrrLrBZqeAdfVEceq1A==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/abort-controller/-/abort-controller-0.16.3.tgz",
+      "integrity": "sha512-bS7IUJFyPf7g1Q9++jH+yuIN/cNWsxtnBKQpmjcZYkCmIK0A91NnPY5b2F1y0kdK4wZqsBef0GMfv/CxB+FAkQ==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.16.1"
+        "@gjsify/dom-events": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/web-globals/node_modules/@gjsify/abort-controller/node_modules/@gjsify/dom-events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.1.tgz",
-      "integrity": "sha512-KQweggtpj4yvKH5QZsgKc5l2MC0Uj+sXy2FGfInQ/FvUbm5V0z/lHE8csPfRwpT0/If2FraINvdZjINmxSAIpg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.3.tgz",
+      "integrity": "sha512-CIxUMh3M9+I/V9LOmVdPw0ghJ0JG0DIdKJ17ltmI7FKwfdw37JmVmDvnPjuLgTxrH5arCieiD4FCg8CPdIC5uQ==",
       "dependencies": {
-        "@gjsify/dom-exception": "^0.16.1"
+        "@gjsify/dom-exception": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/web-globals/node_modules/@gjsify/abort-controller/node_modules/@gjsify/dom-events/node_modules/@gjsify/dom-exception": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.1.tgz",
-      "integrity": "sha512-vOg3Hb7KAqbh3bpEeasI41e6gasvihupzCJEfKVE81FsMbW88SRFWJ8+T049X21+G8jCWG19Jitaq3fLU1gE1g=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.3.tgz",
+      "integrity": "sha512-QbRlQp40v44iV0OmuNR3l01mftHFow/XDxWJt2HV64zbj/F+e7Lzt33w5zII3GVzXHoix+GBkJrazVBbtILmYA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/web-globals/node_modules/@gjsify/buffer": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.1.tgz",
-      "integrity": "sha512-dgapws5yErcmSb2EzKau/HOx7+oRmWnq25RIBv8ujmoq42hInIy1lrkpS0zqJtktqJEVO0yZi3JVedVkH/pzlw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.3.tgz",
+      "integrity": "sha512-dGzEBnIvm98W2Je8nWBH2k4ctHUerqZ8ABLr6QJ3JZHUaoYdQASQwVxsfzzxfkFu5/i/IEL/cNZVEKGet8sfeg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/web-globals/node_modules/@gjsify/buffer/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -18247,25 +18248,25 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/web-globals/node_modules/@gjsify/compression-streams": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/compression-streams/-/compression-streams-0.16.1.tgz",
-      "integrity": "sha512-8Z+aJWr4tHhOo2g14MWbQ5ig+Eu9+kPCOxhgFzXXP6V8hxh1UPexFfzHhuu7sKT5N4kjTiq/PwQPE2rOnaNSCw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/compression-streams/-/compression-streams-0.16.3.tgz",
+      "integrity": "sha512-U5HkaEDlyoDvsw3g5BfGX/7iHJi3CXrkfhQP+g6aVkkMRC68Btz6MvEHolW0huCyethvxFmc6M5MroMj3Eg8EQ==",
       "dependencies": {
-        "@gjsify/web-streams": "^0.16.1"
+        "@gjsify/web-streams": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/web-globals/node_modules/@gjsify/compression-streams/node_modules/@gjsify/web-streams": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.1.tgz",
-      "integrity": "sha512-lBmnY/4IibT8igGmy/IrtcZQrQxZvW49cjwnIJ0Ty0GrpVgWg+8r2YE38iLj+BdVYMht8GFRPemWudRqJKN2kw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.3.tgz",
+      "integrity": "sha512-L+TQa0M2rNnvOQyvoB7ow73DEx5j8FFjKqNB0sqIRKbzYJiNXvHXngTcGjHlPKDHmBtwGL34hBBuUUzQzLZ9Gg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/web-globals/node_modules/@gjsify/compression-streams/node_modules/@gjsify/web-streams/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -18383,57 +18384,57 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/web-globals/node_modules/@gjsify/dom-events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.1.tgz",
-      "integrity": "sha512-KQweggtpj4yvKH5QZsgKc5l2MC0Uj+sXy2FGfInQ/FvUbm5V0z/lHE8csPfRwpT0/If2FraINvdZjINmxSAIpg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.3.tgz",
+      "integrity": "sha512-CIxUMh3M9+I/V9LOmVdPw0ghJ0JG0DIdKJ17ltmI7FKwfdw37JmVmDvnPjuLgTxrH5arCieiD4FCg8CPdIC5uQ==",
       "dependencies": {
-        "@gjsify/dom-exception": "^0.16.1"
+        "@gjsify/dom-exception": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/web-globals/node_modules/@gjsify/dom-events/node_modules/@gjsify/dom-exception": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.1.tgz",
-      "integrity": "sha512-vOg3Hb7KAqbh3bpEeasI41e6gasvihupzCJEfKVE81FsMbW88SRFWJ8+T049X21+G8jCWG19Jitaq3fLU1gE1g=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.3.tgz",
+      "integrity": "sha512-QbRlQp40v44iV0OmuNR3l01mftHFow/XDxWJt2HV64zbj/F+e7Lzt33w5zII3GVzXHoix+GBkJrazVBbtILmYA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/web-globals/node_modules/@gjsify/dom-exception": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.1.tgz",
-      "integrity": "sha512-vOg3Hb7KAqbh3bpEeasI41e6gasvihupzCJEfKVE81FsMbW88SRFWJ8+T049X21+G8jCWG19Jitaq3fLU1gE1g=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.3.tgz",
+      "integrity": "sha512-QbRlQp40v44iV0OmuNR3l01mftHFow/XDxWJt2HV64zbj/F+e7Lzt33w5zII3GVzXHoix+GBkJrazVBbtILmYA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/web-globals/node_modules/@gjsify/eventsource": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/eventsource/-/eventsource-0.16.1.tgz",
-      "integrity": "sha512-djkt0P7NG5J1GTq1oSY+hKSr1f++emffWACkC4r5GJOCo+IiJt/i0JcNElTBqjmsY3zf1H7qgfF/2mnpLyuQ/Q==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/eventsource/-/eventsource-0.16.3.tgz",
+      "integrity": "sha512-pfxbtjErw/h0KPxx89+iYJtkAecZ5tzoYn9tB8M9reVJcEeE7DxnFRIAgjE6eFepSgrVVDaQHQrLeLtPIv2lFw==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.16.1",
-        "@gjsify/web-streams": "^0.16.1"
+        "@gjsify/dom-events": "^0.16.3",
+        "@gjsify/web-streams": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/web-globals/node_modules/@gjsify/eventsource/node_modules/@gjsify/dom-events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.1.tgz",
-      "integrity": "sha512-KQweggtpj4yvKH5QZsgKc5l2MC0Uj+sXy2FGfInQ/FvUbm5V0z/lHE8csPfRwpT0/If2FraINvdZjINmxSAIpg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.3.tgz",
+      "integrity": "sha512-CIxUMh3M9+I/V9LOmVdPw0ghJ0JG0DIdKJ17ltmI7FKwfdw37JmVmDvnPjuLgTxrH5arCieiD4FCg8CPdIC5uQ==",
       "dependencies": {
-        "@gjsify/dom-exception": "^0.16.1"
+        "@gjsify/dom-exception": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/web-globals/node_modules/@gjsify/eventsource/node_modules/@gjsify/dom-events/node_modules/@gjsify/dom-exception": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.1.tgz",
-      "integrity": "sha512-vOg3Hb7KAqbh3bpEeasI41e6gasvihupzCJEfKVE81FsMbW88SRFWJ8+T049X21+G8jCWG19Jitaq3fLU1gE1g=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.3.tgz",
+      "integrity": "sha512-QbRlQp40v44iV0OmuNR3l01mftHFow/XDxWJt2HV64zbj/F+e7Lzt33w5zII3GVzXHoix+GBkJrazVBbtILmYA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/web-globals/node_modules/@gjsify/eventsource/node_modules/@gjsify/web-streams": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.1.tgz",
-      "integrity": "sha512-lBmnY/4IibT8igGmy/IrtcZQrQxZvW49cjwnIJ0Ty0GrpVgWg+8r2YE38iLj+BdVYMht8GFRPemWudRqJKN2kw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.3.tgz",
+      "integrity": "sha512-L+TQa0M2rNnvOQyvoB7ow73DEx5j8FFjKqNB0sqIRKbzYJiNXvHXngTcGjHlPKDHmBtwGL34hBBuUUzQzLZ9Gg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/web-globals/node_modules/@gjsify/eventsource/node_modules/@gjsify/web-streams/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -18551,40 +18552,40 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/web-globals/node_modules/@gjsify/formdata": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/formdata/-/formdata-0.16.1.tgz",
-      "integrity": "sha512-9UJUf687+rMxewxvMVTSdhHbJgmJj0a1+X5W11I3EgEtQ76Lxbb8U1ZGe90rkrj2+9oteKjaLMNdthcQSkBzCQ=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/formdata/-/formdata-0.16.3.tgz",
+      "integrity": "sha512-p+Fao6I59Uh6wvZf+i0VSFLC7AzpcoGfFUU8GQ5Mv1V8NrbJ2FfqBOUprP31fT9DH0O3f7S7Az8Z8zJ/h/HIsA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/web-globals/node_modules/@gjsify/gamepad": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/gamepad/-/gamepad-0.16.1.tgz",
-      "integrity": "sha512-0B77qIU2D9Bn0IU4Kao/pwpSrJT9h9uDfDQZeJARkx4VJLvi8WPTbbT+AxUcCFpHpRfr/WOgDlKldz8XVN/5KA==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/gamepad/-/gamepad-0.16.3.tgz",
+      "integrity": "sha512-h1SLHT6ZwfD1BXHStxrBaQevy3kV6ueEpH5eLODDwLXgtwFg3lRgJxrIqRqqlLn81Sz9S/VTKCs6aYEcWYHTYw==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.16.1"
+        "@gjsify/dom-events": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/web-globals/node_modules/@gjsify/gamepad/node_modules/@gjsify/dom-events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.1.tgz",
-      "integrity": "sha512-KQweggtpj4yvKH5QZsgKc5l2MC0Uj+sXy2FGfInQ/FvUbm5V0z/lHE8csPfRwpT0/If2FraINvdZjINmxSAIpg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.3.tgz",
+      "integrity": "sha512-CIxUMh3M9+I/V9LOmVdPw0ghJ0JG0DIdKJ17ltmI7FKwfdw37JmVmDvnPjuLgTxrH5arCieiD4FCg8CPdIC5uQ==",
       "dependencies": {
-        "@gjsify/dom-exception": "^0.16.1"
+        "@gjsify/dom-exception": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/web-globals/node_modules/@gjsify/gamepad/node_modules/@gjsify/dom-events/node_modules/@gjsify/dom-exception": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.1.tgz",
-      "integrity": "sha512-vOg3Hb7KAqbh3bpEeasI41e6gasvihupzCJEfKVE81FsMbW88SRFWJ8+T049X21+G8jCWG19Jitaq3fLU1gE1g=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.3.tgz",
+      "integrity": "sha512-QbRlQp40v44iV0OmuNR3l01mftHFow/XDxWJt2HV64zbj/F+e7Lzt33w5zII3GVzXHoix+GBkJrazVBbtILmYA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/web-globals/node_modules/@gjsify/perf_hooks": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/perf_hooks/-/perf_hooks-0.16.1.tgz",
-      "integrity": "sha512-OpqLO1CgW48+vpgqXHIH1aCwyfyG6wnzIyCHA+4a3pZ3Mipbkwrv6yrie+7qi1kQyvRKi9m6JitmTnKBLN7pPg=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/perf_hooks/-/perf_hooks-0.16.3.tgz",
+      "integrity": "sha512-j/lLGVxEnI73jBlVxDmhwzKkOpTHEmlOEe+MYbvT9l0XeNoRTAM3OPjDh/HnI4EYdGRD5uciGBthL9BxDVjspQ=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/web-globals/node_modules/@gjsify/url": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.16.1.tgz",
-      "integrity": "sha512-+enwAVUFMLMrca9spA2sjHcZJuHLWMSLqG5TuLRbpNcKAhnUxkAK1vERZ10rj8Y9Jo639Y+q0t9vqUxHR+sKmg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.16.3.tgz",
+      "integrity": "sha512-7oNt6TYBQCzKcf/7D8v2nBqw/D+a0rzuQ1J4jITqO/nHYQXGt4oV7RaLa7sC6EHNaoj0l9sUKPP3IMhm2+RNNw==",
       "dependencies": {
         "@girs/glib-2.0": "^4.1.0"
       }
@@ -18650,17 +18651,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/web-globals/node_modules/@gjsify/web-streams": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.1.tgz",
-      "integrity": "sha512-lBmnY/4IibT8igGmy/IrtcZQrQxZvW49cjwnIJ0Ty0GrpVgWg+8r2YE38iLj+BdVYMht8GFRPemWudRqJKN2kw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.3.tgz",
+      "integrity": "sha512-L+TQa0M2rNnvOQyvoB7ow73DEx5j8FFjKqNB0sqIRKbzYJiNXvHXngTcGjHlPKDHmBtwGL34hBBuUUzQzLZ9Gg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/web-globals/node_modules/@gjsify/web-streams/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -18778,51 +18779,51 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/web-globals/node_modules/@gjsify/webaudio": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/webaudio/-/webaudio-0.16.1.tgz",
-      "integrity": "sha512-Xiky5oXuTQ+kArxJAZtItG+CEDyLxTDST2U/z1tL3Px25H7PN+d8IBGGbU4MsSwHByJG2ku+kv8Lsa9zTdWOaA==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/webaudio/-/webaudio-0.16.3.tgz",
+      "integrity": "sha512-JDvvDPyrpgAA3bXITK1XGUos1qOaMjBIX1lwxwTN8Oq1FHAmTZ7F2TSeMnTnEnpv5yPQL4Ot/HDbiyVWXBtGog==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.16.1"
+        "@gjsify/dom-events": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/web-globals/node_modules/@gjsify/webaudio/node_modules/@gjsify/dom-events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.1.tgz",
-      "integrity": "sha512-KQweggtpj4yvKH5QZsgKc5l2MC0Uj+sXy2FGfInQ/FvUbm5V0z/lHE8csPfRwpT0/If2FraINvdZjINmxSAIpg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.3.tgz",
+      "integrity": "sha512-CIxUMh3M9+I/V9LOmVdPw0ghJ0JG0DIdKJ17ltmI7FKwfdw37JmVmDvnPjuLgTxrH5arCieiD4FCg8CPdIC5uQ==",
       "dependencies": {
-        "@gjsify/dom-exception": "^0.16.1"
+        "@gjsify/dom-exception": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/web-globals/node_modules/@gjsify/webaudio/node_modules/@gjsify/dom-events/node_modules/@gjsify/dom-exception": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.1.tgz",
-      "integrity": "sha512-vOg3Hb7KAqbh3bpEeasI41e6gasvihupzCJEfKVE81FsMbW88SRFWJ8+T049X21+G8jCWG19Jitaq3fLU1gE1g=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.3.tgz",
+      "integrity": "sha512-QbRlQp40v44iV0OmuNR3l01mftHFow/XDxWJt2HV64zbj/F+e7Lzt33w5zII3GVzXHoix+GBkJrazVBbtILmYA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/web-globals/node_modules/@gjsify/webcrypto": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/webcrypto/-/webcrypto-0.16.1.tgz",
-      "integrity": "sha512-Gv1sZ23mEUjV1pxEfd5AGpCUVOVMNt6dfdKGBZyQwyCM4yOw824awfi0xjBDl0H3g7C60v+sHCgH31oR+nRYnQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/webcrypto/-/webcrypto-0.16.3.tgz",
+      "integrity": "sha512-g1MvSs8uRg0l9JVxa5JT7xiZ4Z9I2/QM1RTKnBodGZSmnbFk9KmyMKHu5tPhXthJjlNFpctMbOV4ISiJy0l14w==",
       "dependencies": {
-        "@gjsify/dom-exception": "^0.16.1"
+        "@gjsify/dom-exception": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/web-globals/node_modules/@gjsify/webcrypto/node_modules/@gjsify/dom-exception": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.1.tgz",
-      "integrity": "sha512-vOg3Hb7KAqbh3bpEeasI41e6gasvihupzCJEfKVE81FsMbW88SRFWJ8+T049X21+G8jCWG19Jitaq3fLU1gE1g=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.3.tgz",
+      "integrity": "sha512-QbRlQp40v44iV0OmuNR3l01mftHFow/XDxWJt2HV64zbj/F+e7Lzt33w5zII3GVzXHoix+GBkJrazVBbtILmYA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/web-streams": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.1.tgz",
-      "integrity": "sha512-lBmnY/4IibT8igGmy/IrtcZQrQxZvW49cjwnIJ0Ty0GrpVgWg+8r2YE38iLj+BdVYMht8GFRPemWudRqJKN2kw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.3.tgz",
+      "integrity": "sha512-L+TQa0M2rNnvOQyvoB7ow73DEx5j8FFjKqNB0sqIRKbzYJiNXvHXngTcGjHlPKDHmBtwGL34hBBuUUzQzLZ9Gg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/web-streams/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -18940,54 +18941,54 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/webassembly": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/webassembly/-/webassembly-0.16.1.tgz",
-      "integrity": "sha512-SBhRMrRWQA+7taIzHDyORuGP4NyzgPtttDJdPYhoFQ2GZH9zgBcR7+wj0E6Bakzdw9UWhXNfxVa1PZsbuo/7yA=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/webassembly/-/webassembly-0.16.3.tgz",
+      "integrity": "sha512-USTHoOOz5vzIOTHwES3dbi9J3XzlMtUdgOWOiXKeosJUkvWvU23Lg76EtbLyOQho46HyxlGhVuYcgiRtWl8VcA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/webaudio": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/webaudio/-/webaudio-0.16.1.tgz",
-      "integrity": "sha512-Xiky5oXuTQ+kArxJAZtItG+CEDyLxTDST2U/z1tL3Px25H7PN+d8IBGGbU4MsSwHByJG2ku+kv8Lsa9zTdWOaA==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/webaudio/-/webaudio-0.16.3.tgz",
+      "integrity": "sha512-JDvvDPyrpgAA3bXITK1XGUos1qOaMjBIX1lwxwTN8Oq1FHAmTZ7F2TSeMnTnEnpv5yPQL4Ot/HDbiyVWXBtGog==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.16.1"
+        "@gjsify/dom-events": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/webaudio/node_modules/@gjsify/dom-events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.1.tgz",
-      "integrity": "sha512-KQweggtpj4yvKH5QZsgKc5l2MC0Uj+sXy2FGfInQ/FvUbm5V0z/lHE8csPfRwpT0/If2FraINvdZjINmxSAIpg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.3.tgz",
+      "integrity": "sha512-CIxUMh3M9+I/V9LOmVdPw0ghJ0JG0DIdKJ17ltmI7FKwfdw37JmVmDvnPjuLgTxrH5arCieiD4FCg8CPdIC5uQ==",
       "dependencies": {
-        "@gjsify/dom-exception": "^0.16.1"
+        "@gjsify/dom-exception": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/webaudio/node_modules/@gjsify/dom-events/node_modules/@gjsify/dom-exception": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.1.tgz",
-      "integrity": "sha512-vOg3Hb7KAqbh3bpEeasI41e6gasvihupzCJEfKVE81FsMbW88SRFWJ8+T049X21+G8jCWG19Jitaq3fLU1gE1g=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.3.tgz",
+      "integrity": "sha512-QbRlQp40v44iV0OmuNR3l01mftHFow/XDxWJt2HV64zbj/F+e7Lzt33w5zII3GVzXHoix+GBkJrazVBbtILmYA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/webcrypto": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/webcrypto/-/webcrypto-0.16.1.tgz",
-      "integrity": "sha512-Gv1sZ23mEUjV1pxEfd5AGpCUVOVMNt6dfdKGBZyQwyCM4yOw824awfi0xjBDl0H3g7C60v+sHCgH31oR+nRYnQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/webcrypto/-/webcrypto-0.16.3.tgz",
+      "integrity": "sha512-g1MvSs8uRg0l9JVxa5JT7xiZ4Z9I2/QM1RTKnBodGZSmnbFk9KmyMKHu5tPhXthJjlNFpctMbOV4ISiJy0l14w==",
       "dependencies": {
-        "@gjsify/dom-exception": "^0.16.1"
+        "@gjsify/dom-exception": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/webcrypto/node_modules/@gjsify/dom-exception": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.1.tgz",
-      "integrity": "sha512-vOg3Hb7KAqbh3bpEeasI41e6gasvihupzCJEfKVE81FsMbW88SRFWJ8+T049X21+G8jCWG19Jitaq3fLU1gE1g=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.3.tgz",
+      "integrity": "sha512-QbRlQp40v44iV0OmuNR3l01mftHFow/XDxWJt2HV64zbj/F+e7Lzt33w5zII3GVzXHoix+GBkJrazVBbtILmYA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/websocket": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/websocket/-/websocket-0.16.1.tgz",
-      "integrity": "sha512-LxwYCJbBvbHHfa6qlIN92cknD9mxlvpt5DmlH6fAq7JSLlL/wouUtxw2IovAbWgagIwqbHMaQfkL2G5WM/KjTQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/websocket/-/websocket-0.16.3.tgz",
+      "integrity": "sha512-Njq0Z9OefOHXAXmGv498nTV2d3uuO7eh2vTjEdvMeA9l7JjF+slqRu04YH0ajyoZZnLNk1yCLi3iZ5vlLY39KA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/gjs": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
         "@girs/soup-3.0": "^4.1.0",
-        "@gjsify/dom-events": "^0.16.1"
+        "@gjsify/dom-events": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/websocket/node_modules/@girs/gio-2.0": {
@@ -19100,32 +19101,32 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/websocket/node_modules/@gjsify/dom-events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.1.tgz",
-      "integrity": "sha512-KQweggtpj4yvKH5QZsgKc5l2MC0Uj+sXy2FGfInQ/FvUbm5V0z/lHE8csPfRwpT0/If2FraINvdZjINmxSAIpg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.3.tgz",
+      "integrity": "sha512-CIxUMh3M9+I/V9LOmVdPw0ghJ0JG0DIdKJ17ltmI7FKwfdw37JmVmDvnPjuLgTxrH5arCieiD4FCg8CPdIC5uQ==",
       "dependencies": {
-        "@gjsify/dom-exception": "^0.16.1"
+        "@gjsify/dom-exception": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/websocket/node_modules/@gjsify/dom-events/node_modules/@gjsify/dom-exception": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.1.tgz",
-      "integrity": "sha512-vOg3Hb7KAqbh3bpEeasI41e6gasvihupzCJEfKVE81FsMbW88SRFWJ8+T049X21+G8jCWG19Jitaq3fLU1gE1g=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.3.tgz",
+      "integrity": "sha512-QbRlQp40v44iV0OmuNR3l01mftHFow/XDxWJt2HV64zbj/F+e7Lzt33w5zII3GVzXHoix+GBkJrazVBbtILmYA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/webstorage": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/webstorage/-/webstorage-0.16.1.tgz",
-      "integrity": "sha512-Y5lq2FCuOQZHlrzGRVwHZkpGdO27FxBS2C8FNTkpGO88eQVAhDAavib6qA57JFmKp5ykxFjowjJ4SOnYWea2NQ=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/webstorage/-/webstorage-0.16.3.tgz",
+      "integrity": "sha512-ZF1EahltYQ0lOgwWwbFuaylIKE8FcYVxTXKwVimAp9XHw9cRotsT34cvPaIIq7cQNhhBc/n3s64akqBCcxwpvw=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/xmlhttprequest": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/xmlhttprequest/-/xmlhttprequest-0.16.1.tgz",
-      "integrity": "sha512-RJxkBa7HokrWIbVjPjHgb/IBWU49n08w9Q8iOlk6uWUOOQqxPlPIgEV0gNea0RMoqIbEpsgTrXDhEGgtFllQFA==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/xmlhttprequest/-/xmlhttprequest-0.16.3.tgz",
+      "integrity": "sha512-UqpKWF3k2+EBP6Fk8t+KKd25futOWN84ZDvKCSN+67l422UK5YtzaKtgE3b83gjqzpiWwWi82FULNf2RHUeP+g==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/gjs": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/fetch": "^0.16.1"
+        "@gjsify/fetch": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/xmlhttprequest/node_modules/@girs/gio-2.0": {
@@ -19207,18 +19208,18 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/xmlhttprequest/node_modules/@gjsify/fetch": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/fetch/-/fetch-0.16.1.tgz",
-      "integrity": "sha512-MavUbh5kJzRSQGVdriqKvvvRTchicy19o8yKKAI9p5CWR2/98AS38nmGqOtco0P0VumeBPbbU3QRMejZv6tGBA==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/fetch/-/fetch-0.16.3.tgz",
+      "integrity": "sha512-eAsOvuuctoMeGx7F35sMeP1siB8fU7mxMr7deJBnFQAZm8k/oEALhassb5M6tMub2voK3ECNPv/2QuthC7mOeA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/gjs": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
         "@girs/soup-3.0": "^4.1.0",
-        "@gjsify/formdata": "^0.16.1",
-        "@gjsify/http": "^0.16.1",
-        "@gjsify/url": "^0.16.1",
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/formdata": "^0.16.3",
+        "@gjsify/http": "^0.16.3",
+        "@gjsify/url": "^0.16.3",
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/xmlhttprequest/node_modules/@gjsify/fetch/node_modules/@girs/soup-3.0": {
@@ -19253,39 +19254,39 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/xmlhttprequest/node_modules/@gjsify/fetch/node_modules/@gjsify/formdata": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/formdata/-/formdata-0.16.1.tgz",
-      "integrity": "sha512-9UJUf687+rMxewxvMVTSdhHbJgmJj0a1+X5W11I3EgEtQ76Lxbb8U1ZGe90rkrj2+9oteKjaLMNdthcQSkBzCQ=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/formdata/-/formdata-0.16.3.tgz",
+      "integrity": "sha512-p+Fao6I59Uh6wvZf+i0VSFLC7AzpcoGfFUU8GQ5Mv1V8NrbJ2FfqBOUprP31fT9DH0O3f7S7Az8Z8zJ/h/HIsA=="
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/xmlhttprequest/node_modules/@gjsify/fetch/node_modules/@gjsify/http": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/http/-/http-0.16.1.tgz",
-      "integrity": "sha512-LoMdpA5z5nhEH+Rbn5LOuNUHQ/knzcQMA2WvxFMTm1iyWrfgYdaDiDoMMHcOq52QnF7rR79c2KA0ehyOntY1Rg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/http/-/http-0.16.3.tgz",
+      "integrity": "sha512-SLdgQz6NhtH1HG8BfoBN9ozf4XkTkkW92YT/NJjvND6uk3oL9C4WvAmv/YEttaHjHfWoaNog1R06Rg5/UHUtEg==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
         "@girs/soup-3.0": "^4.1.0",
-        "@gjsify/buffer": "^0.16.1",
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/http-soup-bridge": "^0.16.1",
-        "@gjsify/net": "^0.16.1",
-        "@gjsify/stream": "^0.16.1",
-        "@gjsify/url": "^0.16.1",
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/buffer": "^0.16.3",
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/http-soup-bridge": "^0.16.3",
+        "@gjsify/net": "^0.16.3",
+        "@gjsify/stream": "^0.16.3",
+        "@gjsify/url": "^0.16.3",
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/xmlhttprequest/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/buffer": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.1.tgz",
-      "integrity": "sha512-dgapws5yErcmSb2EzKau/HOx7+oRmWnq25RIBv8ujmoq42hInIy1lrkpS0zqJtktqJEVO0yZi3JVedVkH/pzlw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.3.tgz",
+      "integrity": "sha512-dGzEBnIvm98W2Je8nWBH2k4ctHUerqZ8ABLr6QJ3JZHUaoYdQASQwVxsfzzxfkFu5/i/IEL/cNZVEKGet8sfeg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/xmlhttprequest/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/buffer/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -19325,17 +19326,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/xmlhttprequest/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/xmlhttprequest/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -19375,9 +19376,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/xmlhttprequest/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/http-soup-bridge": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge/-/http-soup-bridge-0.16.1.tgz",
-      "integrity": "sha512-WRWNT6LmkNaacSMo+R2x2QFVqld9H2grjM6RnEG2rvCb3M9horIsuM7kGNjlUpWor3vb7KQ8KVJ8BOtoo+MXoQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge/-/http-soup-bridge-0.16.3.tgz",
+      "integrity": "sha512-PUf2QVNAZDPJuRsEdwgxs4/bV+iP0SSlcterP0benh9xUjFWB6RDuv3rsJWtaNdnleD+lky9zGpYJbG+MpkhqA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/gjs": "^4.1.0",
@@ -19396,30 +19397,30 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/xmlhttprequest/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/net": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/net/-/net-0.16.1.tgz",
-      "integrity": "sha512-fMFXtl0KAt+IEUwU+TuiB70kyYi7J8xu4MURDo9aXI1yzIblCXyMxRw/fGuRECLpsAeJONl/6ckIlPrst/Hf9g==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/net/-/net-0.16.3.tgz",
+      "integrity": "sha512-mFVIDc38GAPz1TKNE5zRP0SacVMAucaC/YvNQtpR6ISs/EicfWvgWt+XDckYgizKSmL2dJlYkGKnlwUbxZ9jtg==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/buffer": "^0.16.1",
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/stream": "^0.16.1",
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/buffer": "^0.16.3",
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/stream": "^0.16.3",
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/xmlhttprequest/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/buffer": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.1.tgz",
-      "integrity": "sha512-dgapws5yErcmSb2EzKau/HOx7+oRmWnq25RIBv8ujmoq42hInIy1lrkpS0zqJtktqJEVO0yZi3JVedVkH/pzlw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.3.tgz",
+      "integrity": "sha512-dGzEBnIvm98W2Je8nWBH2k4ctHUerqZ8ABLr6QJ3JZHUaoYdQASQwVxsfzzxfkFu5/i/IEL/cNZVEKGet8sfeg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/xmlhttprequest/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/buffer/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -19459,17 +19460,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/xmlhttprequest/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/xmlhttprequest/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -19509,27 +19510,27 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/xmlhttprequest/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/stream": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.1.tgz",
-      "integrity": "sha512-KFm9H/6uLmmQoPtMAI9y9Or4aLip0qf24lQxU0wDTuIEcbMHpXN9vc4fHDrz5Qg03CffkfvHzh2jA8RDQQ9A6g==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.3.tgz",
+      "integrity": "sha512-jk2DfOKMdOPpU+Pjq5QE6qr9xVrQ3eXsepFtwLg/cGYAxG7xw/0/tI9BSinPVUF+PBEsFaX+Y6jz2HQokJsiuQ==",
       "dependencies": {
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/utils": "^0.16.1",
-        "@gjsify/web-streams": "^0.16.1"
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/utils": "^0.16.3",
+        "@gjsify/web-streams": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/xmlhttprequest/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/xmlhttprequest/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -19569,9 +19570,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/xmlhttprequest/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -19611,17 +19612,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/xmlhttprequest/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.1.tgz",
-      "integrity": "sha512-lBmnY/4IibT8igGmy/IrtcZQrQxZvW49cjwnIJ0Ty0GrpVgWg+8r2YE38iLj+BdVYMht8GFRPemWudRqJKN2kw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.3.tgz",
+      "integrity": "sha512-L+TQa0M2rNnvOQyvoB7ow73DEx5j8FFjKqNB0sqIRKbzYJiNXvHXngTcGjHlPKDHmBtwGL34hBBuUUzQzLZ9Gg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/xmlhttprequest/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -19661,9 +19662,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/xmlhttprequest/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/net/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -19703,27 +19704,27 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/xmlhttprequest/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/stream": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.1.tgz",
-      "integrity": "sha512-KFm9H/6uLmmQoPtMAI9y9Or4aLip0qf24lQxU0wDTuIEcbMHpXN9vc4fHDrz5Qg03CffkfvHzh2jA8RDQQ9A6g==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.3.tgz",
+      "integrity": "sha512-jk2DfOKMdOPpU+Pjq5QE6qr9xVrQ3eXsepFtwLg/cGYAxG7xw/0/tI9BSinPVUF+PBEsFaX+Y6jz2HQokJsiuQ==",
       "dependencies": {
-        "@gjsify/events": "^0.16.1",
-        "@gjsify/utils": "^0.16.1",
-        "@gjsify/web-streams": "^0.16.1"
+        "@gjsify/events": "^0.16.3",
+        "@gjsify/utils": "^0.16.3",
+        "@gjsify/web-streams": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/xmlhttprequest/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/stream/node_modules/@gjsify/events": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-      "integrity": "sha512-9eGIovEhq1uVKAVGwOPjZdwKogk8qUZJNtAkZxKf+eukJ9JHpmC1OB0AM9JFpa3wJ0Us9XVNi0WZpuyUGBv3Gg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+      "integrity": "sha512-uej/XDbjlPgLfC8Aj4TJfLpvCKm0Ax3MTCvPcl3VT0hm8BmY4EEF7Q/cDVh0zoSYAw7rkHNDnc9VPGVq61cUEw==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/xmlhttprequest/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/stream/node_modules/@gjsify/events/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -19763,9 +19764,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/xmlhttprequest/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/stream/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -19805,17 +19806,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/xmlhttprequest/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.1.tgz",
-      "integrity": "sha512-lBmnY/4IibT8igGmy/IrtcZQrQxZvW49cjwnIJ0Ty0GrpVgWg+8r2YE38iLj+BdVYMht8GFRPemWudRqJKN2kw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.3.tgz",
+      "integrity": "sha512-L+TQa0M2rNnvOQyvoB7ow73DEx5j8FFjKqNB0sqIRKbzYJiNXvHXngTcGjHlPKDHmBtwGL34hBBuUUzQzLZ9Gg==",
       "dependencies": {
-        "@gjsify/utils": "^0.16.1"
+        "@gjsify/utils": "^0.16.3"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/xmlhttprequest/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/stream/node_modules/@gjsify/web-streams/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -19855,17 +19856,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/xmlhttprequest/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/url": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.16.1.tgz",
-      "integrity": "sha512-+enwAVUFMLMrca9spA2sjHcZJuHLWMSLqG5TuLRbpNcKAhnUxkAK1vERZ10rj8Y9Jo639Y+q0t9vqUxHR+sKmg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.16.3.tgz",
+      "integrity": "sha512-7oNt6TYBQCzKcf/7D8v2nBqw/D+a0rzuQ1J4jITqO/nHYQXGt4oV7RaLa7sC6EHNaoj0l9sUKPP3IMhm2+RNNw==",
       "dependencies": {
         "@girs/glib-2.0": "^4.1.0"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/xmlhttprequest/node_modules/@gjsify/fetch/node_modules/@gjsify/http/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -19905,17 +19906,17 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/xmlhttprequest/node_modules/@gjsify/fetch/node_modules/@gjsify/url": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.16.1.tgz",
-      "integrity": "sha512-+enwAVUFMLMrca9spA2sjHcZJuHLWMSLqG5TuLRbpNcKAhnUxkAK1vERZ10rj8Y9Jo639Y+q0t9vqUxHR+sKmg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.16.3.tgz",
+      "integrity": "sha512-7oNt6TYBQCzKcf/7D8v2nBqw/D+a0rzuQ1J4jITqO/nHYQXGt4oV7RaLa7sC6EHNaoj0l9sUKPP3IMhm2+RNNw==",
       "dependencies": {
         "@girs/glib-2.0": "^4.1.0"
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/web-polyfills/node_modules/@gjsify/xmlhttprequest/node_modules/@gjsify/fetch/node_modules/@gjsify/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-t8PXeWt6Qz8ZFT1167Zd6bye/784Asg3zSuGiqMv1SzvO7CU/rsvZ1h//pXxOe/kjGpohz59YNLbxat3NG3OwQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+      "integrity": "sha512-pqbuSQzPIpdKXeJtbO6r7EOxEDHrgYyjFJTKBcKGfU/lwe+DDkztNAIpT2DrVjrgsaIUF1KwyRdIgO0cSE3tAA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -19955,122 +19956,9 @@
       }
     },
     "node_modules/@gjsify/cli/node_modules/@gjsify/workspace": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/workspace/-/workspace-0.16.1.tgz",
-      "integrity": "sha512-jz8uJ45oWdlCy+ij9EyrxRn81heWT3fASYT8ChePteNrpLrQWER46b23kDJh3uvLE491zCViBvgMJdsXCEtbxw=="
-    },
-    "node_modules/@gjsify/cli/node_modules/rolldown": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
-      "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
-      "dependencies": {
-        "@oxc-project/types": "=0.138.0",
-        "@rolldown/pluginutils": "^1.0.0"
-      },
-      "bin": {
-        "rolldown": "./bin/cli.mjs"
-      }
-    },
-    "node_modules/@gjsify/cli/node_modules/rolldown/node_modules/@oxc-project/types": {
-      "version": "0.138.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
-      "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA=="
-    },
-    "node_modules/@gjsify/cli/node_modules/rolldown/node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
-      "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw=="
-    },
-    "node_modules/@gjsify/cli/node_modules/rolldown/node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
-      "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ=="
-    },
-    "node_modules/@gjsify/cli/node_modules/rolldown/node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
-      "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg=="
-    },
-    "node_modules/@gjsify/cli/node_modules/rolldown/node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
-      "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ=="
-    },
-    "node_modules/@gjsify/cli/node_modules/rolldown/node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
-      "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA=="
-    },
-    "node_modules/@gjsify/cli/node_modules/rolldown/node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
-      "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w=="
-    },
-    "node_modules/@gjsify/cli/node_modules/rolldown/node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
-      "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng=="
-    },
-    "node_modules/@gjsify/cli/node_modules/rolldown/node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
-      "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg=="
-    },
-    "node_modules/@gjsify/cli/node_modules/rolldown/node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
-      "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ=="
-    },
-    "node_modules/@gjsify/cli/node_modules/rolldown/node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
-      "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw=="
-    },
-    "node_modules/@gjsify/cli/node_modules/rolldown/node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
-      "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ=="
-    },
-    "node_modules/@gjsify/cli/node_modules/rolldown/node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
-      "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA=="
-    },
-    "node_modules/@gjsify/cli/node_modules/rolldown/node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
-      "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
-      "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.6",
-        "@emnapi/core": "1.11.1",
-        "@emnapi/runtime": "1.11.1"
-      }
-    },
-    "node_modules/@gjsify/cli/node_modules/rolldown/node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.3"
-      }
-    },
-    "node_modules/@gjsify/cli/node_modules/rolldown/node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime/node_modules/@tybys/wasm-util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
-      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@gjsify/cli/node_modules/rolldown/node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
-      "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA=="
-    },
-    "node_modules/@gjsify/cli/node_modules/rolldown/node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
-      "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/workspace/-/workspace-0.16.3.tgz",
+      "integrity": "sha512-58ZpL57w1/TeQJ1v7EVnh0mK5PPzBeYF7wq/RVvIkfjz0HODqbIQ95X+qT+FUsuNJLDyiS+zKgtCnHi19qU+xg=="
     },
     "node_modules/@gjsify/cluster": {
       "version": "0.10.0",
@@ -20193,9 +20081,9 @@
       "integrity": "sha512-QpMWinc880TGX4dOU3p1GuECulim2trRW0ASTshHNRTlnIVgBVvZmVUkW50jA0TDDBHRjQe2NsBAxHXSEniGfg=="
     },
     "node_modules/@gjsify/empty": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/empty/-/empty-0.16.1.tgz",
-      "integrity": "sha512-ojuzwFl7kjm1Qon/Yw4vRZ/a7K+KUUm13iR18XVuBqzmXfVhYsbQsiEXA93C8XUuGAzFFhJPwd5BlX2xoQ6O6w=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/empty/-/empty-0.16.3.tgz",
+      "integrity": "sha512-YEwtqPbX2INvn9lQw41Ori/t4Pr4JbdFRXGwH64WOWt8u4O3buBhVZafcBwd5tEK8ekX3/UakZW68cK7t6mADA=="
     },
     "node_modules/@gjsify/events": {
       "version": "0.10.0",
@@ -20569,9 +20457,9 @@
       }
     },
     "node_modules/@gjsify/rolldown-plugin-deepkit": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-deepkit/-/rolldown-plugin-deepkit-0.16.1.tgz",
-      "integrity": "sha512-/IA4CGVLbbajTliV0VeqEIadrc7XaiCrGbQD93UOe6Wp2BgdTov3k2ToRP4ExfnaL7tMJ7VCsF8p4Q1jgvj8zQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-deepkit/-/rolldown-plugin-deepkit-0.16.3.tgz",
+      "integrity": "sha512-sroyIVC29eOgRxuPtZZlGGWQUCq7MNImpMbE43udlKW5YOhigpLrTvLwtXxH29O57GwRK9v+jcq8rKzGSwwxPw==",
       "dependencies": {
         "@deepkit/type-compiler": "^1.0.19",
         "typescript": "^6.0.3"
@@ -20792,53 +20680,54 @@
       }
     },
     "node_modules/@gjsify/vite-plugin-gjsify": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/vite-plugin-gjsify/-/vite-plugin-gjsify-0.16.1.tgz",
-      "integrity": "sha512-HViBOa9ZPQA7cNQDg7eLM/qgoUoNVHN7wqurc187d0aWjKfVnqNzupdMDqWEChQs8XwxD1bsEukpkJ5Y1Z+kGQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/vite-plugin-gjsify/-/vite-plugin-gjsify-0.16.3.tgz",
+      "integrity": "sha512-FLp7Oju8vlTy6ZYIdGBkLrBCSN8rUnBKpHx8OklB2u1bOI6YW7oIhTSYk0hpIJCPsbFc/8j5SMiQkv/8q8jZHQ==",
       "dependencies": {
-        "@gjsify/empty": "^0.16.1",
-        "@gjsify/resolve-npm": "^0.16.1",
-        "@gjsify/rolldown-plugin-deepkit": "^0.16.1",
-        "@gjsify/rolldown-plugin-gjsify": "^0.16.1",
-        "@gjsify/vite-plugin-blueprint": "^0.16.1"
+        "@gjsify/empty": "^0.16.3",
+        "@gjsify/resolve-npm": "^0.16.3",
+        "@gjsify/rolldown-plugin-deepkit": "^0.16.3",
+        "@gjsify/rolldown-plugin-gjsify": "^0.16.3",
+        "@gjsify/vite-plugin-blueprint": "^0.16.3"
       }
     },
     "node_modules/@gjsify/vite-plugin-gjsify/node_modules/@gjsify/resolve-npm": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/resolve-npm/-/resolve-npm-0.16.1.tgz",
-      "integrity": "sha512-0PiEGEh+IeyZW0QZn5xUhJfhTZOg7kX9pS3QlygOnYibJBzYX4gGFKfirHcv5gTtJaAyMjzilo+mMdQ6r7GWQg=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/resolve-npm/-/resolve-npm-0.16.3.tgz",
+      "integrity": "sha512-nM+R8TXAJTcOqFSo32kb2tiLyKH4vjmQ19ZESOK1QVDw0K9SrteY+rGPB6zj5a0L/8S6y2EWk/CQZY712F2P1w=="
     },
     "node_modules/@gjsify/vite-plugin-gjsify/node_modules/@gjsify/rolldown-plugin-gjsify": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-gjsify/-/rolldown-plugin-gjsify-0.16.1.tgz",
-      "integrity": "sha512-lUzFB1hX47lgmQXd1z+nU//iGktUJYYVu0eTBAPC9AOMVCRp8Fse5s6ndiLcgX0aZurlf7993G9Zx55eJGq0+g==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-gjsify/-/rolldown-plugin-gjsify-0.16.3.tgz",
+      "integrity": "sha512-3/Rkh4n1d1ggTwtBVIN6UdRCA4n/UhhedBv//HSR0d+h8PyZ8Kg8i+4CJi8MJp0wstJJkABtON1fDmKS9u2pRA==",
       "dependencies": {
-        "@gjsify/console": "^0.16.1",
-        "@gjsify/resolve-npm": "^0.16.1",
-        "@gjsify/rolldown-plugin-deepkit": "^0.16.1",
-        "@gjsify/rolldown-plugin-pnp": "^0.16.1",
-        "@gjsify/vite-plugin-blueprint": "^0.16.1",
+        "@gjsify/console": "^0.16.3",
+        "@gjsify/resolve-npm": "^0.16.3",
+        "@gjsify/rolldown-plugin-deepkit": "^0.16.3",
+        "@gjsify/rolldown-plugin-pnp": "^0.16.3",
+        "@gjsify/vite-plugin-blueprint": "^0.16.3",
         "@rollup/pluginutils": "^5.4.0",
         "acorn": "^8.17.0",
         "acorn-walk": "^8.3.5",
         "fast-glob": "^3.3.3",
-        "lightningcss": "^1.32.0"
+        "lightningcss": "^1.32.0",
+        "sass": "^1.101.0"
       }
     },
     "node_modules/@gjsify/vite-plugin-gjsify/node_modules/@gjsify/rolldown-plugin-gjsify/node_modules/@gjsify/console": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/console/-/console-0.16.1.tgz",
-      "integrity": "sha512-QI4X3eWBc8+QL/cBQJi7tMxbKMKxudNJYnm/wk+iBvL2tSqMxWfSaxFW/ftntluTUQlm6N1e0x6/YZAshnMWgg=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/console/-/console-0.16.3.tgz",
+      "integrity": "sha512-6qDtkJM/LDiFu/CS4COGAnHY5xxD9Vbe9LbN60ZI4o2p31p68vmzFp7Jo70b1pQohl6KheYGpJnO5y0KFURa/Q=="
     },
     "node_modules/@gjsify/vite-plugin-gjsify/node_modules/@gjsify/rolldown-plugin-gjsify/node_modules/@gjsify/rolldown-plugin-pnp": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-pnp/-/rolldown-plugin-pnp-0.16.1.tgz",
-      "integrity": "sha512-SBPjXSYOzP7Mly4zoKHefzcGAbgDe2rTDdKBRjsBgquKsBcCvckFgKrviLBQpz19bGYJWtTrCgDT8xEA7+UECg=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-pnp/-/rolldown-plugin-pnp-0.16.3.tgz",
+      "integrity": "sha512-lwyRFAPaXG4coqiV5BM7bEh8i+/PruHt7gtkcZczx2K9TlhuwL5ffVDV8onh4f1d7RcwElWEILUbmM7bc8p4gg=="
     },
     "node_modules/@gjsify/vite-plugin-gjsify/node_modules/@gjsify/vite-plugin-blueprint": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@gjsify/vite-plugin-blueprint/-/vite-plugin-blueprint-0.16.1.tgz",
-      "integrity": "sha512-xYyJjrQs4G00M8EK5plCM35U1pvWCyggruAMFJNZNASclGzDVY5/P5F5la1vpHsLRozO4rkypuR8GNaxok0m9Q==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@gjsify/vite-plugin-blueprint/-/vite-plugin-blueprint-0.16.3.tgz",
+      "integrity": "sha512-8t2fbdYaRLIICdVlZlYAq+rSnxe3dTZCzn0Cxsn6Fsz9a61yjpFO/NiJhGh8zP+b45TDbpWzBxmvHOuKoULGPw==",
       "dependencies": {
         "execa": "^9.6.1",
         "minify-xml": "^4.5.2"
@@ -21636,11 +21525,11 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
-      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.2"
+        "@tybys/wasm-util": "^0.10.3"
       }
     },
     "node_modules/@nativescript/android": {
@@ -22112,9 +22001,9 @@
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.137.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
-      "integrity": "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA=="
+      "version": "0.138.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
+      "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA=="
     },
     "node_modules/@oxfmt/binding-android-arm-eabi": {
       "version": "0.53.0",
@@ -22397,84 +22286,84 @@
       "integrity": "sha512-/JqGCvHpj0PxS9cyZPP5LpiEy1pYszgWor/JTyreHQwLPQQdxO1mUYTtRribYcVosxH7FFs0GJBtJ652nlwKyw=="
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.2.tgz",
-      "integrity": "sha512-2cZ+7xRS+DBcuJBJKnfzsbleumJhBqSlJVpuzHC0nTqfd3QQ7Vx2/x5YR/D7cBamKSeWplwo82Fn9lqYUDEMfA=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
+      "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw=="
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.2.tgz",
-      "integrity": "sha512-RkPMJnygxsgOYdkfqgpwY0/Fzm8d0VQe6HGU2/B00Xa9eqdLbrII+DOKAodbJAn3ZL1AJxGHkZRPYazgGY6Ljw=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
+      "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ=="
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.2.tgz",
-      "integrity": "sha512-Uiczh6vFhwyfd7WNe7Q7mCA4KxAiLdz7jPE/WGizfRpIieoyFuNVMmM8HqZ9HwudTkY6/AeMQwlNJ9NJijguWw=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
+      "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg=="
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.2.tgz",
-      "integrity": "sha512-+TpdtTRgHiJFjCVFbw311SuLk3KfytPOQQn+VlAEv+gBxYPtL7E6JS9e/tk+8CwxhIZvemJKo4rTKgfWNsKkkA=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
+      "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ=="
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.2.tgz",
-      "integrity": "sha512-4lv1/tkmi7ueIVHnyreaOeUpiZP26BH9rRy6hoYfR9310A2B9nUEVRDvBx69vx64Nr3eTPPRkyciqJJs+j9Jmw=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
+      "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA=="
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.2.tgz",
-      "integrity": "sha512-gBSUVO0eaWgw1JMjK3gB8BMlX2Mk148s2lTiVT3e9vjVxbl7UDfMWWY8CfIaaqiXuM9fVTMxIpUz6CAo/B6Vlw=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
+      "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w=="
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.2.tgz",
-      "integrity": "sha512-LjQP/iZLBu8o8PjIfk4x3At0/mT6h282pvz8Z5LAyhGbu/kDezyO7ea62rF5uoqmgnIYqbN/MqJ3Si3Aymi7xQ=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
+      "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng=="
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.2.tgz",
-      "integrity": "sha512-X/7bVLWelEsbyWDUSXt7zVsTniLLPIY2n1rH58qr78l9i7MNbbxBWD8gI2vRfBWf4NUXJCUuQnfZDsp32LqsfQ=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
+      "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg=="
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.2.tgz",
-      "integrity": "sha512-gb6dYKW/1KDorGXyy48glEBJs/sxVSC5pcVrox/pFGV4mvwSFeg2sK5L2tRkVsVlh7kueqOgg4GEcuipJcGuKg=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
+      "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ=="
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.2.tgz",
-      "integrity": "sha512-JY4w85pU3iAiJVMh5nuk4/Mh9GjMsupe8MrIN53rwxAZW64GKrWeJBuN6SxQg9QTU5uB1cxyhDzW8jqRn1EABw=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
+      "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw=="
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.2.tgz",
-      "integrity": "sha512-xvpA7o5KCYLB0Rwscmuylb1/zHHSUx4g4xilm4prC5jP76pEUlzBmMbgpbh7bVDbId4NcfT96gN5i6mE6UDaiw=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
+      "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ=="
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.2.tgz",
-      "integrity": "sha512-p/ts6KBLjuk49Bp21XH77poQGt02iNz7ChgHep7tudPOaLinR/De/RHdxF8w8Yj4r/bF/bqXwH6PZrB2sA+Nvw=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
+      "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA=="
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.2.tgz",
-      "integrity": "sha512-VMu/wmrZ9hJzYlRhbw7jK5PODlugyKZ5mOdX78+lS8OvuFkWNQdz1pFLrI2p3P0pjXOmUZ7B48o5VnMH9QOGtg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
+      "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
       "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.6",
         "@emnapi/core": "1.11.1",
-        "@emnapi/runtime": "1.11.1",
-        "@napi-rs/wasm-runtime": "^1.1.5"
+        "@emnapi/runtime": "1.11.1"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.2.tgz",
-      "integrity": "sha512-xtUJqs8qEkuSviS0n1tsohaPuz3a1SPhZywOji4Oo+sgrJs8daEDMZ0QtqL0OS7dx8PoVpg2J/ZZycPY5I2+Zg=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
+      "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA=="
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.2.tgz",
-      "integrity": "sha512-85YiLQqjUKgSO/Zjnf9e0XIn5Ymrh1fLDWBeAkZqpuBR/3R8TpfoHXuyblqyQrftSSgWO9qpcHN8mkyKsLraoA=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
+      "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ=="
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.1",
@@ -22759,9 +22648,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -27727,11 +27616,11 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="
     },
     "node_modules/rolldown": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.2.tgz",
-      "integrity": "sha512-x0CrQQqCXWGeI8dTvFfN/Dnv3yMKT9hv5jFjlOreKAx9wqLq9wz7VvLLHyaAXC90/CpggTu9SisSbsJJTPSjNQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
+      "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
       "dependencies": {
-        "@oxc-project/types": "=0.137.0",
+        "@oxc-project/types": "=0.138.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {

--- a/gjsify-sources.json
+++ b/gjsify-sources.json
@@ -1212,10 +1212,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/abort-controller/-/abort-controller-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/66",
-    "dest-filename": "6694322e3c4497028888369212c2f4e5e044af0ecf879e657e3df4c0d350faa270101f18491c028c4e77341c84aabb085f94a3aeb2eb059a9e01d7d511c7aad4.tgz",
-    "sha512": "6694322e3c4497028888369212c2f4e5e044af0ecf879e657e3df4c0d350faa270101f18491c028c4e77341c84aabb085f94a3aeb2eb059a9e01d7d511c7aad4"
+    "url": "https://registry.npmjs.org/@gjsify/abort-controller/-/abort-controller-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/6d",
+    "dest-filename": "6d2ec85091723dfee0d50f7efa31fecae20dfdc356b31b6704a4299a37196240a620ad00f753673d8e5bd85d72d2474ae3066ab0179fd0631fbff0b107e14091.tgz",
+    "sha512": "6d2ec85091723dfee0d50f7efa31fecae20dfdc356b31b6704a4299a37196240a620ad00f753673d8e5bd85d72d2474ae3066ab0179fd0631fbff0b107e14091"
   },
   {
     "type": "file",
@@ -1226,10 +1226,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/adwaita-fonts/-/adwaita-fonts-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/de",
-    "dest-filename": "de0ce1e2f48a31678f0f2534303df5d89ca99b3c31971a89080b25cf81467c7f2fa4799f0de25ce85a629a288c22371ae0cc81986d8fe42bef216e1999b2b1f1.tgz",
-    "sha512": "de0ce1e2f48a31678f0f2534303df5d89ca99b3c31971a89080b25cf81467c7f2fa4799f0de25ce85a629a288c22371ae0cc81986d8fe42bef216e1999b2b1f1"
+    "url": "https://registry.npmjs.org/@gjsify/adwaita-fonts/-/adwaita-fonts-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/7d",
+    "dest-filename": "7d0fbf277fa12a449310c64354216d6032a53501995fa38f0042c9e75a326f6199b1a066efc1cfb24a7f95b66d2051a4e0faa5f95e301ce13043036bc48a90af.tgz",
+    "sha512": "7d0fbf277fa12a449310c64354216d6032a53501995fa38f0042c9e75a326f6199b1a066efc1cfb24a7f95b66d2051a4e0faa5f95e301ce13043036bc48a90af"
   },
   {
     "type": "file",
@@ -1240,10 +1240,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/adwaita-icons/-/adwaita-icons-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/05",
-    "dest-filename": "05bb57a1d3b60afe2d1888d2ae05771f305d091b4862bae34c421f1cfa9f95768be9cdd6908e8a9b85e87dd4c5f13fb6505999b9ccd01936c0b76fca00da3d67.tgz",
-    "sha512": "05bb57a1d3b60afe2d1888d2ae05771f305d091b4862bae34c421f1cfa9f95768be9cdd6908e8a9b85e87dd4c5f13fb6505999b9ccd01936c0b76fca00da3d67"
+    "url": "https://registry.npmjs.org/@gjsify/adwaita-icons/-/adwaita-icons-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/23",
+    "dest-filename": "23dd24e7096e0537bb9933bd718367ce0904735781aad15dda55f282dff978a9f410f87bba34da0ff723c5627db34faa34256263a4df6146d240ce744144a4bc.tgz",
+    "sha512": "23dd24e7096e0537bb9933bd718367ce0904735781aad15dda55f282dff978a9f410f87bba34da0ff723c5627db34faa34256263a4df6146d240ce744144a4bc"
   },
   {
     "type": "file",
@@ -1254,10 +1254,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/adwaita-web/-/adwaita-web-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/a4",
-    "dest-filename": "a4824d8732c209c53494ce072d4e9fe2164d1e5b28496a20000646686428b6f8d6ef8781ae61a4bf334bd823f813490519fd7d9f57849030399c70461f43ba05.tgz",
-    "sha512": "a4824d8732c209c53494ce072d4e9fe2164d1e5b28496a20000646686428b6f8d6ef8781ae61a4bf334bd823f813490519fd7d9f57849030399c70461f43ba05"
+    "url": "https://registry.npmjs.org/@gjsify/adwaita-web/-/adwaita-web-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/b5",
+    "dest-filename": "b5e50decdd95a51ebe8cfa867a24cf676ae31aa67fa7e019a8f54b02dc3e7666ea872e7c11dca56351d3f9aa5580dbb67d51d061ac110f1acb8dedfcc56f2679.tgz",
+    "sha512": "b5e50decdd95a51ebe8cfa867a24cf676ae31aa67fa7e019a8f54b02dc3e7666ea872e7c11dca56351d3f9aa5580dbb67d51d061ac110f1acb8dedfcc56f2679"
   },
   {
     "type": "file",
@@ -1268,10 +1268,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/assert/-/assert-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/5a",
-    "dest-filename": "5ac3b48e53489911cd2e0f1c8ca56cf03484fc93c8e01ba4e51e4c5c7ef6db0144eeb339a352c06ed5b3335c7a6f50b68b967c49d95db97ec2561f53ceda370d.tgz",
-    "sha512": "5ac3b48e53489911cd2e0f1c8ca56cf03484fc93c8e01ba4e51e4c5c7ef6db0144eeb339a352c06ed5b3335c7a6f50b68b967c49d95db97ec2561f53ceda370d"
+    "url": "https://registry.npmjs.org/@gjsify/assert/-/assert-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/59",
+    "dest-filename": "59686bc4a7f23cd12cedfbbcbb63a4943699d247bec16752eb95b92867a3c7e93c4f278bc195f837ec50f23f63c0ca49083b868eb09c4ffc907871c79158b51a.tgz",
+    "sha512": "59686bc4a7f23cd12cedfbbcbb63a4943699d247bec16752eb95b92867a3c7e93c4f278bc195f837ec50f23f63c0ca49083b868eb09c4ffc907871c79158b51a"
   },
   {
     "type": "file",
@@ -1282,10 +1282,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/async_hooks/-/async_hooks-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/1d",
-    "dest-filename": "1d45e1fddc5c77b77a266a16a6ee5a40e223bd2e5fdc0274d9172fd49ea747b2eee787e47878c0360403543765cb5e1bae61d6cadcf755f7658365a45d1d486b.tgz",
-    "sha512": "1d45e1fddc5c77b77a266a16a6ee5a40e223bd2e5fdc0274d9172fd49ea747b2eee787e47878c0360403543765cb5e1bae61d6cadcf755f7658365a45d1d486b"
+    "url": "https://registry.npmjs.org/@gjsify/async_hooks/-/async_hooks-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/bb",
+    "dest-filename": "bb9ef1ffea472899015375fa28ae1047b0a31cfbb80c428dd3de5385d059a0274958f7f3ddde6a9cf98f1380d44616ded537a71232042a7b1719c7ce1bd4ebfe.tgz",
+    "sha512": "bb9ef1ffea472899015375fa28ae1047b0a31cfbb80c428dd3de5385d059a0274958f7f3ddde6a9cf98f1380d44616ded537a71232042a7b1719c7ce1bd4ebfe"
   },
   {
     "type": "file",
@@ -1296,10 +1296,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/76",
-    "dest-filename": "7606a9c2ce7212b72649bd84cca6aefc73b1efea119969eadb944806ff2e8e6a2ae368489c8cb596b9294b4cea26d92da891153b4c998b725579d5641ffa7397.tgz",
-    "sha512": "7606a9c2ce7212b72649bd84cca6aefc73b1efea119969eadb944806ff2e8e6a2ae368489c8cb596b9294b4cea26d92da891153b4c998b725579d5641ffa7397"
+    "url": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/74",
+    "dest-filename": "746cc406722f9bdf16d897bc9d6047da4e1cb4751eaea67c0012ebe902772591d46a861d400490c15c6c7f3cf17e416ee7f8bf2042ff70d65510a19eb7cb1f7a.tgz",
+    "sha512": "746cc406722f9bdf16d897bc9d6047da4e1cb4751eaea67c0012ebe902772591d46a861d400490c15c6c7f3cf17e416ee7f8bf2042ff70d65510a19eb7cb1f7a"
   },
   {
     "type": "file",
@@ -1317,17 +1317,17 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/child_process/-/child_process-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/f5",
-    "dest-filename": "f5faa63722f038c25595e192b16e5acbef9fb565accb669c7c805116f17cb153bf51d870d376551543739f72a01d4265fa6f34e3b06bd3c65b4f1a1b2a26f8b6.tgz",
-    "sha512": "f5faa63722f038c25595e192b16e5acbef9fb565accb669c7c805116f17cb153bf51d870d376551543739f72a01d4265fa6f34e3b06bd3c65b4f1a1b2a26f8b6"
+    "url": "https://registry.npmjs.org/@gjsify/child_process/-/child_process-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/5a",
+    "dest-filename": "5afceb6b853d062fadcd6fd644e0bb423479502242a0af2a520a7a22e9480ee93f299cfd9392e3f8b29d37bc918edce41d828f3cbc3f232d0c2783415018ed18.tgz",
+    "sha512": "5afceb6b853d062fadcd6fd644e0bb423479502242a0af2a520a7a22e9480ee93f299cfd9392e3f8b29d37bc918edce41d828f3cbc3f232d0c2783415018ed18"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/cli/-/cli-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/db",
-    "dest-filename": "db47ab3d43279c52f36c5b8d3320a4bcc4ebd958e49bf1826cf60135951330079dce73569cadd278fe5baca4f7e455bc19959880dad29a400d534d7956e16845.tgz",
-    "sha512": "db47ab3d43279c52f36c5b8d3320a4bcc4ebd958e49bf1826cf60135951330079dce73569cadd278fe5baca4f7e455bc19959880dad29a400d534d7956e16845"
+    "url": "https://registry.npmjs.org/@gjsify/cli/-/cli-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/d9",
+    "dest-filename": "d93cd75702b127f178e9ebae86247b81a5d8259da5df2fe2b339fd1ebc26e636b7305c25d86411758f9ff15ec1430479ed5964f40b9b21cad05080956fe92490.tgz",
+    "sha512": "d93cd75702b127f178e9ebae86247b81a5d8259da5df2fe2b339fd1ebc26e636b7305c25d86411758f9ff15ec1430479ed5964f40b9b21cad05080956fe92490"
   },
   {
     "type": "file",
@@ -1338,10 +1338,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/cluster/-/cluster-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/1e",
-    "dest-filename": "1e8e72b598fcacb646063fe71afbf86c82be1f46051a9a143a6177e295ee68a5d135eceb1507884e5e19726023565b2db548decd9583f7461d373beeccf68865.tgz",
-    "sha512": "1e8e72b598fcacb646063fe71afbf86c82be1f46051a9a143a6177e295ee68a5d135eceb1507884e5e19726023565b2db548decd9583f7461d373beeccf68865"
+    "url": "https://registry.npmjs.org/@gjsify/cluster/-/cluster-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/a7",
+    "dest-filename": "a78653f3a7962ccc694727d43f53ae60a9c7c0820e77186a045f65c1655c31a21e975b0cc7d2e30088e0aa28a09890af3b46db2178ecb3d2ce2185e8c78319fd.tgz",
+    "sha512": "a78653f3a7962ccc694727d43f53ae60a9c7c0820e77186a045f65c1655c31a21e975b0cc7d2e30088e0aa28a09890af3b46db2178ecb3d2ce2185e8c78319fd"
   },
   {
     "type": "file",
@@ -1352,10 +1352,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/compression-streams/-/compression-streams-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/f1",
-    "dest-filename": "f19f9a256af8b4784ea36835e0c59b4398a0f84bbdfa43c23b18601735d73fa57c87187550f7b115fcc786ebbbb0a4f93789234e2abf3f040f136ace9da3520b.tgz",
-    "sha512": "f19f9a256af8b4784ea36835e0c59b4398a0f84bbdfa43c23b18601735d73fa57c87187550f7b115fcc786ebbbb0a4f93789234e2abf3f040f136ace9da3520b"
+    "url": "https://registry.npmjs.org/@gjsify/compression-streams/-/compression-streams-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/53",
+    "dest-filename": "5391e46840e5ca80efb30de0e417c65ffee21c98b7097ae47e140ffa0e9a56490c442ebc06dcfa32f107a255b486e0b27ad86fc4599ce8ce4cae8323dc483c11.tgz",
+    "sha512": "5391e46840e5ca80efb30de0e417c65ffee21c98b7097ae47e140ffa0e9a56490c442ebc06dcfa32f107a255b486e0b27ad86fc4599ce8ce4cae8323dc483c11"
   },
   {
     "type": "file",
@@ -1373,10 +1373,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/console/-/console-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/40",
-    "dest-filename": "408e17dde58173cf902ff7014098bbb4cc5b28c2b1b9d3496279bfc24fa206f2f6b52a8cc567d26b1156fdfb67b65b93510966e8dd5ed31ebf61902c86731682.tgz",
-    "sha512": "408e17dde58173cf902ff7014098bbb4cc5b28c2b1b9d3496279bfc24fa206f2f6b52a8cc567d26b1156fdfb67b65b93510966e8dd5ed31ebf61902c86731682"
+    "url": "https://registry.npmjs.org/@gjsify/console/-/console-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/ea",
+    "dest-filename": "eaa0ed90933f2c3885bbf092e023860271d8e71c43f556def4b6cdeb4648e28da9df5a7af2f9b3169ec9a3bd1bd69428865e8a85e606a499cee72d0a15445afd.tgz",
+    "sha512": "eaa0ed90933f2c3885bbf092e023860271d8e71c43f556def4b6cdeb4648e28da9df5a7af2f9b3169ec9a3bd1bd69428865e8a85e606a499cee72d0a15445afd"
   },
   {
     "type": "file",
@@ -1387,10 +1387,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/constants/-/constants-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/fa",
-    "dest-filename": "faff303562ab022f2e6214ad802148d8d882efee50f853e2afd678e2baf7eb71b203f68f3ccb0cc2f64a9dc9ef80749f17f74563c170dafb5717900fa70902e4.tgz",
-    "sha512": "faff303562ab022f2e6214ad802148d8d882efee50f853e2afd678e2baf7eb71b203f68f3ccb0cc2f64a9dc9ef80749f17f74563c170dafb5717900fa70902e4"
+    "url": "https://registry.npmjs.org/@gjsify/constants/-/constants-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/09",
+    "dest-filename": "092f7422f97f26c560e444abf6bdc3fbea40d4847c8ef869fd29f665c963e31933f27e941831b2678777ff6ab77d6ef98b2cd61c40b0440bd5880be5f7be115b.tgz",
+    "sha512": "092f7422f97f26c560e444abf6bdc3fbea40d4847c8ef869fd29f665c963e31933f27e941831b2678777ff6ab77d6ef98b2cd61c40b0440bd5880be5f7be115b"
   },
   {
     "type": "file",
@@ -1401,10 +1401,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/create-app/-/create-app-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/85",
-    "dest-filename": "85dcb6d1aeff9299f3e0d3033e6553ea136ee71d89d26db9f1f1aabee32d79e92901ccd5f504759a4c7d0ab20d29515649b302354543e4bf62b732b6262a9580.tgz",
-    "sha512": "85dcb6d1aeff9299f3e0d3033e6553ea136ee71d89d26db9f1f1aabee32d79e92901ccd5f504759a4c7d0ab20d29515649b302354543e4bf62b732b6262a9580"
+    "url": "https://registry.npmjs.org/@gjsify/create-app/-/create-app-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/08",
+    "dest-filename": "08c1d0220c9175a4a74c0a3bcefcfa88add394252531a0746f2d62929c431c5530407853e479b057a7d664366a3a733a5f89a20aa1a07211cec88e0bb8e68a21.tgz",
+    "sha512": "08c1d0220c9175a4a74c0a3bcefcfa88add394252531a0746f2d62929c431c5530407853e479b057a7d664366a3a733a5f89a20aa1a07211cec88e0bb8e68a21"
   },
   {
     "type": "file",
@@ -1415,10 +1415,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/crypto/-/crypto-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/2b",
-    "dest-filename": "2b6b9b5213a9735f7782f1bf0ade17190aaa26640d3f894a0730f9ddd4df8c0565828ea1e1cd91350c19169e36370cf733353d4a4caa82c1848f7e0e9a30e1d1.tgz",
-    "sha512": "2b6b9b5213a9735f7782f1bf0ade17190aaa26640d3f894a0730f9ddd4df8c0565828ea1e1cd91350c19169e36370cf733353d4a4caa82c1848f7e0e9a30e1d1"
+    "url": "https://registry.npmjs.org/@gjsify/crypto/-/crypto-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/77",
+    "dest-filename": "772a9fe942dfeb0286bb4a8d706a788f005275270037d588f7af22c6847388d648bc0b72222051ad9d2f1db1343aceffe4e60ee23b5f539fd14315d31a97556b.tgz",
+    "sha512": "772a9fe942dfeb0286bb4a8d706a788f005275270037d588f7af22c6847388d648bc0b72222051ad9d2f1db1343aceffe4e60ee23b5f539fd14315d31a97556b"
   },
   {
     "type": "file",
@@ -1429,10 +1429,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/dgram/-/dgram-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/00",
-    "dest-filename": "0025b0cc08193493fb65ee564c415f7f36d4b488b408b770ebd7fc9886abfdbae731330380d6decb6a764d8e2ef062744be4f76dd9f43e010d33d75cb6198fbf.tgz",
-    "sha512": "0025b0cc08193493fb65ee564c415f7f36d4b488b408b770ebd7fc9886abfdbae731330380d6decb6a764d8e2ef062744be4f76dd9f43e010d33d75cb6198fbf"
+    "url": "https://registry.npmjs.org/@gjsify/dgram/-/dgram-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/24",
+    "dest-filename": "24f27537f7d048c6c894c96895bff1200ce02729ce0a3117429f2d2a1dba86d0f1766539c4b6be3bb6452a0bc56e68855e122ae972e7c4c0cb02996e3e36ccb0.tgz",
+    "sha512": "24f27537f7d048c6c894c96895bff1200ce02729ce0a3117429f2d2a1dba86d0f1766539c4b6be3bb6452a0bc56e68855e122ae972e7c4c0cb02996e3e36ccb0"
   },
   {
     "type": "file",
@@ -1443,10 +1443,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/diagnostics_channel/-/diagnostics_channel-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/24",
-    "dest-filename": "2413b211294548d3a58bdeecc79e5d88f1279997f2ef1e47eee54986eaa19f7ae5a3bb3d1e8838682a60a75776b00f7c25980af4b11ea65e96efd4340c80b0b7.tgz",
-    "sha512": "2413b211294548d3a58bdeecc79e5d88f1279997f2ef1e47eee54986eaa19f7ae5a3bb3d1e8838682a60a75776b00f7c25980af4b11ea65e96efd4340c80b0b7"
+    "url": "https://registry.npmjs.org/@gjsify/diagnostics_channel/-/diagnostics_channel-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/f4",
+    "dest-filename": "f47e46e26f1707ccac9738c8385a57fdac430cad87665c29943e0bc08ecf3ee5bff0e72f3adb94d67a9274bf0dc0b17bcabe702dd89b9f275c1f7891751722b6.tgz",
+    "sha512": "f47e46e26f1707ccac9738c8385a57fdac430cad87665c29943e0bc08ecf3ee5bff0e72f3adb94d67a9274bf0dc0b17bcabe702dd89b9f275c1f7891751722b6"
   },
   {
     "type": "file",
@@ -1457,10 +1457,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/dns/-/dns-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/83",
-    "dest-filename": "835f966b3cf4e385b694eb5f99d7140fbcfecc41c715ad653b19dfa5a44348b40e61e88e2baf6f19ba0150dd12461b9c38cd1097d8f7efa3a59a81595c3c8770.tgz",
-    "sha512": "835f966b3cf4e385b694eb5f99d7140fbcfecc41c715ad653b19dfa5a44348b40e61e88e2baf6f19ba0150dd12461b9c38cd1097d8f7efa3a59a81595c3c8770"
+    "url": "https://registry.npmjs.org/@gjsify/dns/-/dns-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/6b",
+    "dest-filename": "6ba243cf618c63404a299914aea08489a529ce92910121e9ccf711d885fe3068dd3cc4bf8acd12f776059cbe2589f05acf11a331085a9511e49f1caf9d0c8cc5.tgz",
+    "sha512": "6ba243cf618c63404a299914aea08489a529ce92910121e9ccf711d885fe3068dd3cc4bf8acd12f776059cbe2589f05acf11a331085a9511e49f1caf9d0c8cc5"
   },
   {
     "type": "file",
@@ -1478,10 +1478,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/29",
-    "dest-filename": "290c1e820b698f8caf287e5066c80a739976302d148feb17cb61467c89d0fc5bd46e6e55d33fe51c4f1cb0f7d1c294f4fc87f616b68836f7598c8366c52008a6.tgz",
-    "sha512": "290c1e820b698f8caf287e5066c80a739976302d148feb17cb61467c89d0fc5bd46e6e55d33fe51c4f1cb0f7d1c294f4fc87f616b68836f7598c8366c52008a6"
+    "url": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/08",
+    "dest-filename": "088c54321dccf7e23f57d2ce99574fc34821274246d0321d289d7b96d988ec52b07ddc37ec9995983be73e3b8b813c6b1f96ab0a27a20f814283c08f7480b9b9.tgz",
+    "sha512": "088c54321dccf7e23f57d2ce99574fc34821274246d0321d289d7b96d988ec52b07ddc37ec9995983be73e3b8b813c6b1f96ab0a27a20f814283c08f7480b9b9"
   },
   {
     "type": "file",
@@ -1492,10 +1492,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/bc",
-    "dest-filename": "bce8371dbeca02a6e1ddba4479ab08e357ba81ab2f8a1ba9cc22447ca544f3516c31b5bcf12445589f3e4f4e3d5f6d7e1bc8c2586d7d262b5aab77cb535804d6.tgz",
-    "sha512": "bce8371dbeca02a6e1ddba4479ab08e357ba81ab2f8a1ba9cc22447ca544f3516c31b5bcf12445589f3e4f4e3d5f6d7e1bc8c2586d7d262b5aab77cb535804d6"
+    "url": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/41",
+    "dest-filename": "41b465429e34bf8e225743a6b8d477974d667ed1c5a30fd70f1589b761d5eb8cdb8ff17e7bb2f3b77df0e73208dc65735c7a22c7e181909adacd505bb482e660.tgz",
+    "sha512": "41b465429e34bf8e225743a6b8d477974d667ed1c5a30fd70f1589b761d5eb8cdb8ff17e7bb2f3b77df0e73208dc65735c7a22c7e181909adacd505bb482e660"
   },
   {
     "type": "file",
@@ -1506,10 +1506,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/domain/-/domain-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/1a",
-    "dest-filename": "1a7de63d61f4fd020f275879cdee1d5cdec77d431095d09a6e291d7e1943175c435a153e264f7c48a9130282eca224a47be8952e40eeea7e561605abb57287a8.tgz",
-    "sha512": "1a7de63d61f4fd020f275879cdee1d5cdec77d431095d09a6e291d7e1943175c435a153e264f7c48a9130282eca224a47be8952e40eeea7e561605abb57287a8"
+    "url": "https://registry.npmjs.org/@gjsify/domain/-/domain-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/4e",
+    "dest-filename": "4e8075020d5b825660739456396a605e1f1f49ede5ecb6f0bf0fc391a54942387847d1f7ea3ffa82224774e54b5809e50ff6621d347f2f27d59fb362a11b6844.tgz",
+    "sha512": "4e8075020d5b825660739456396a605e1f1f49ede5ecb6f0bf0fc391a54942387847d1f7ea3ffa82224774e54b5809e50ff6621d347f2f27d59fb362a11b6844"
   },
   {
     "type": "file",
@@ -1520,10 +1520,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/domparser/-/domparser-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/b3",
-    "dest-filename": "b396de96a9a696f56cf3d0d5e3f1956ea547c34e4ff18bdd9e3b1d657d6184fc9dfeb7d4fa690d049f1ad86ee9627307c37835d0903ef81a245489fca3ec6529.tgz",
-    "sha512": "b396de96a9a696f56cf3d0d5e3f1956ea547c34e4ff18bdd9e3b1d657d6184fc9dfeb7d4fa690d049f1ad86ee9627307c37835d0903ef81a245489fca3ec6529"
+    "url": "https://registry.npmjs.org/@gjsify/domparser/-/domparser-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/d5",
+    "dest-filename": "d5e5bc53865095a16f1f58acbdd979585838dfe48b0ab58bba2975ece70db26ed04dd0f393c37eda99a5ef8a0af05ecf6cb8bbea31d7ae1a4867f0a4ec74a140.tgz",
+    "sha512": "d5e5bc53865095a16f1f58acbdd979585838dfe48b0ab58bba2975ece70db26ed04dd0f393c37eda99a5ef8a0af05ecf6cb8bbea31d7ae1a4867f0a4ec74a140"
   },
   {
     "type": "file",
@@ -1534,10 +1534,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/empty/-/empty-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/a2",
-    "dest-filename": "a23bb3c0597b9239b54289ff630e2f459fdaecaf8a5149b5de2475f1756e06ace65df56162c6d0b2211703ddc2f1752e180cc516124fc1de41957db1a10e8eeb.tgz",
-    "sha512": "a23bb3c0597b9239b54289ff630e2f459fdaecaf8a5149b5de2475f1756e06ace65df56162c6d0b2211703ddc2f1752e180cc516124fc1de41957db1a10e8eeb"
+    "url": "https://registry.npmjs.org/@gjsify/empty/-/empty-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/60",
+    "dest-filename": "604c2da8f6d7d8836f9fd950c38d4eae2fede0faf825b7454571b01fae16396b7cbb83b76ee06155969f701c1de6d10af1e917dff51a9195baf1c2bbb7a9800c.tgz",
+    "sha512": "604c2da8f6d7d8836f9fd950c38d4eae2fede0faf825b7454571b01fae16396b7cbb83b76ee06155969f701c1de6d10af1e917dff51a9195baf1c2bbb7a9800c"
   },
   {
     "type": "file",
@@ -1548,10 +1548,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/f5",
-    "dest-filename": "f5e188a2f121ab5b95280546c0e3e365dc0aa2093ca9464936d02467129ff9eba427d247a660b5381d0033d245a5adf027452cf5754d8b4599a6ec94181bf71a.tgz",
-    "sha512": "f5e188a2f121ab5b95280546c0e3e365dc0aa2093ca9464936d02467129ff9eba427d247a660b5381d0033d245a5adf027452cf5754d8b4599a6ec94181bf71a"
+    "url": "https://registry.npmjs.org/@gjsify/events/-/events-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/b9",
+    "dest-filename": "b9e8ff5c36e394f80b7c2f008f84c97cba6f08a9b4031dcc4c2bcf725dd54f4866f01998e04105ed0fdc0d5874ce8498030eeb9073439dcf553c656aeb571413.tgz",
+    "sha512": "b9e8ff5c36e394f80b7c2f008f84c97cba6f08a9b4031dcc4c2bcf725dd54f4866f01998e04105ed0fdc0d5874ce8498030eeb9073439dcf553c656aeb571413"
   },
   {
     "type": "file",
@@ -1562,10 +1562,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/eventsource/-/eventsource-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/76",
-    "dest-filename": "76392dd0fecd1b9275193ab5a1263e84a4abd5ffbe7a67df5800a40b8af9189382a3e22226dfe2d0970d1254c1aa39ac637cdfd47eea81f17fda69e92f2b90fd.tgz",
-    "sha512": "76392dd0fecd1b9275193ab5a1263e84a4abd5ffbe7a67df5800a40b8af9189382a3e22226dfe2d0970d1254c1aa39ac637cdfd47eea81f17fda69e92f2b90fd"
+    "url": "https://registry.npmjs.org/@gjsify/eventsource/-/eventsource-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/a5",
+    "dest-filename": "a5fc5bb6312bc3f87428fc71f3dfa2609b6401e719e6dce8627f6d07c33dade549704784ec3c6715120082313a7857a94a0ad55436901d0acb78bb4f22fda517.tgz",
+    "sha512": "a5fc5bb6312bc3f87428fc71f3dfa2609b6401e719e6dce8627f6d07c33dade549704784ec3c6715120082313a7857a94a0ad55436901d0acb78bb4f22fda517"
   },
   {
     "type": "file",
@@ -1576,10 +1576,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/fetch/-/fetch-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/31",
-    "dest-filename": "31abd46e1e6427345240655dae2a8abefbd14dc862732d7da3cc8a28023da79096476ffdf004b7f27986a8eb5ca343f456e99e04f6db53741131e8d9bfab4604.tgz",
-    "sha512": "31abd46e1e6427345240655dae2a8abefbd14dc862732d7da3cc8a28023da79096476ffdf004b7f27986a8eb5ca343f456e99e04f6db53741131e8d9bfab4604"
+    "url": "https://registry.npmjs.org/@gjsify/fetch/-/fetch-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/78",
+    "dest-filename": "780b0ebeeb9cb6831e1b1ec5df9b0c78fd6c881f1f53b9b132bedd7890671500199bc93fa0400b85ab2c6f933ab4cb9bdafa0adc408d3efff642eb610bb98e78.tgz",
+    "sha512": "780b0ebeeb9cb6831e1b1ec5df9b0c78fd6c881f1f53b9b132bedd7890671500199bc93fa0400b85ab2c6f933ab4cb9bdafa0adc408d3efff642eb610bb98e78"
   },
   {
     "type": "file",
@@ -1590,10 +1590,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/formdata/-/formdata-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/f5",
-    "dest-filename": "f542547faf3bfab3317b0c6f3154d27611db2609898f46b5f97e56d7523712012d43be8bc5b6fc5356467bdd2b92b8f6fbda2d78a8da2cc35db617104a407309.tgz",
-    "sha512": "f542547faf3bfab3317b0c6f3154d27611db2609898f46b5f97e56d7523712012d43be8bc5b6fc5356467bdd2b92b8f6fbda2d78a8da2cc35db617104a407309"
+    "url": "https://registry.npmjs.org/@gjsify/formdata/-/formdata-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/a7",
+    "dest-filename": "a7e15aa3a239f5487ac2f65ffa2d154852c2ec0ce972819f15453c190e4cbf557c36b6c9d857ea04e529acfdf57d3f431f43b77fb4bb033f19f3327f87f1c8b0.tgz",
+    "sha512": "a7e15aa3a239f5487ac2f65ffa2d154852c2ec0ce972819f15453c190e4cbf557c36b6c9d857ea04e529acfdf57d3f431f43b77fb4bb033f19f3327f87f1c8b0"
   },
   {
     "type": "file",
@@ -1604,10 +1604,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/fs/-/fs-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/86",
-    "dest-filename": "864afde3bd6a9cac20060fe8f2759b3cf581ba2f5ebee93040e3fb1f78534d13cb445a1905e88fb41bb384fb2a4f8aa5b94c5b6ba2fcc71bb95483c9032709ab.tgz",
-    "sha512": "864afde3bd6a9cac20060fe8f2759b3cf581ba2f5ebee93040e3fb1f78534d13cb445a1905e88fb41bb384fb2a4f8aa5b94c5b6ba2fcc71bb95483c9032709ab"
+    "url": "https://registry.npmjs.org/@gjsify/fs/-/fs-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/5b",
+    "dest-filename": "5b86fb762b0b493fdf5d9d3c929718369643e768ab401b0cfe13fb749986e509b83f8a14b0f6cee9ba4723aa32b0d511b7fff6f34a76e04d90c0b14a87b7af48.tgz",
+    "sha512": "5b86fb762b0b493fdf5d9d3c929718369643e768ab401b0cfe13fb749986e509b83f8a14b0f6cee9ba4723aa32b0d511b7fff6f34a76e04d90c0b14a87b7af48"
   },
   {
     "type": "file",
@@ -1618,10 +1618,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/gamepad/-/gamepad-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/d0",
-    "dest-filename": "d01efba885360fd067d0853829aa3fa70a52ac94fd87db837c3419789011931e1524bbe2f163d36db4fe03151c085a47a517ebfd63a00e52a5773f1754dff928.tgz",
-    "sha512": "d01efba885360fd067d0853829aa3fa70a52ac94fd87db837c3419789011931e1524bbe2f163d36db4fe03151c085a47a517ebfd63a00e52a5773f1754dff928"
+    "url": "https://registry.npmjs.org/@gjsify/gamepad/-/gamepad-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/87",
+    "dest-filename": "87548b1d3e99c1f0f50571d2b71ac16907afcb7915eae784a47e5e2ce0c3c0b5e0b70160de5460271ac8a91aaa94b9fcd52cfd4bf553282b3a69811c5981d363.tgz",
+    "sha512": "87548b1d3e99c1f0f50571d2b71ac16907afcb7915eae784a47e5e2ce0c3c0b5e0b70160de5460271ac8a91aaa94b9fcd52cfd4bf553282b3a69811c5981d363"
   },
   {
     "type": "file",
@@ -1632,10 +1632,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/http-soup-bridge/-/http-soup-bridge-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/59",
-    "dest-filename": "59158d4fa2e690d69a712328f91db1d90155aa577d1f682b8cce919c41b6aef09bdccf61a2b22cb8cee418d8e55295a8af7bdbeca43c29527c04eb68a3e317a1.tgz",
-    "sha512": "59158d4fa2e690d69a712328f91db1d90155aa577d1f682b8cce919c41b6aef09bdccf61a2b22cb8cee418d8e55295a8af7bdbeca43c29527c04eb68a3e317a1"
+    "url": "https://registry.npmjs.org/@gjsify/http-soup-bridge/-/http-soup-bridge-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/3d",
+    "dest-filename": "3d47f64153406433c9b91b04770831b38fdb57e88fd124a572d7ab3f46de9e1f7152315607a443bafdebb095ad68d76795e0fe964cbdcc6a5825b1be329921a8.tgz",
+    "sha512": "3d47f64153406433c9b91b04770831b38fdb57e88fd124a572d7ab3f46de9e1f7152315607a443bafdebb095ad68d76795e0fe964cbdcc6a5825b1be329921a8"
   },
   {
     "type": "file",
@@ -1646,10 +1646,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/http/-/http-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/2e",
-    "dest-filename": "2e831da40e73e678441fe45b9f92ceb8d50743f927cdc40c0365afc453139b58b25ab7e061d683883a0c30770eab9d909c5eeb47bf5cd8a0347a1c8e9ed63546.tgz",
-    "sha512": "2e831da40e73e678441fe45b9f92ceb8d50743f927cdc40c0365afc453139b58b25ab7e061d683883a0c30770eab9d909c5eeb47bf5cd8a0347a1c8e9ed63546"
+    "url": "https://registry.npmjs.org/@gjsify/http/-/http-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/48",
+    "dest-filename": "48b760433e8d86d1f51c6f017e804df68cdfe179139245bdd984ff3498ef343eae937a0bf42e16bc09affd812db5a1e31df5a868da20d51d3a460e7f50752d12.tgz",
+    "sha512": "48b760433e8d86d1f51c6f017e804df68cdfe179139245bdd984ff3498ef343eae937a0bf42e16bc09affd812db5a1e31df5a868da20d51d3a460e7f50752d12"
   },
   {
     "type": "file",
@@ -1660,10 +1660,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/http2-native/-/http2-native-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/03",
-    "dest-filename": "03627061f8092a79f24d3f3515ce766ebda6874776cdb9c2ab8edda2a841ec54ced31ee9e2941955d72a16fd92c3bb53fe3ce5affa345713491445159f4ff821.tgz",
-    "sha512": "03627061f8092a79f24d3f3515ce766ebda6874776cdb9c2ab8edda2a841ec54ced31ee9e2941955d72a16fd92c3bb53fe3ce5affa345713491445159f4ff821"
+    "url": "https://registry.npmjs.org/@gjsify/http2-native/-/http2-native-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/eb",
+    "dest-filename": "eb0523e305c6fd7f0400c1f9e53a94a2449d0761339b92c8d0bed13c1b02aaffbfba24b0af5c913c802f441247f57ac6838cf0485a6b47940651740be64b8b57.tgz",
+    "sha512": "eb0523e305c6fd7f0400c1f9e53a94a2449d0761339b92c8d0bed13c1b02aaffbfba24b0af5c913c802f441247f57ac6838cf0485a6b47940651740be64b8b57"
   },
   {
     "type": "file",
@@ -1674,10 +1674,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/http2/-/http2-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/05",
-    "dest-filename": "0511986bb0455a9feac279ed417d0cd962ebf08bd0e60d13c0ef9f59d0dbadedfdcff9b0a35c4fc25c23fe1421d1e645ab55dbdd95c4cb2a0981345cdc37f5ef.tgz",
-    "sha512": "0511986bb0455a9feac279ed417d0cd962ebf08bd0e60d13c0ef9f59d0dbadedfdcff9b0a35c4fc25c23fe1421d1e645ab55dbdd95c4cb2a0981345cdc37f5ef"
+    "url": "https://registry.npmjs.org/@gjsify/http2/-/http2-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/72",
+    "dest-filename": "7290ada8763f8e1f34ea94d1b3b70e07097e6ce180a8127dfa89ae5bfa4437e4d1ac85176b921ba6df89075673b7ed22efe7e3d2b6a5b10b2918bf4fa66dfae4.tgz",
+    "sha512": "7290ada8763f8e1f34ea94d1b3b70e07097e6ce180a8127dfa89ae5bfa4437e4d1ac85176b921ba6df89075673b7ed22efe7e3d2b6a5b10b2918bf4fa66dfae4"
   },
   {
     "type": "file",
@@ -1688,10 +1688,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/https/-/https-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/03",
-    "dest-filename": "03f1c1703668be964b30eee55543ca8ccd35a2cdf40a07769b4af12e85631993524f7a4ce888ba1ae556739c10f822c49ed00e085fb7da2c8460c18f28daca57.tgz",
-    "sha512": "03f1c1703668be964b30eee55543ca8ccd35a2cdf40a07769b4af12e85631993524f7a4ce888ba1ae556739c10f822c49ed00e085fb7da2c8460c18f28daca57"
+    "url": "https://registry.npmjs.org/@gjsify/https/-/https-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/3d",
+    "dest-filename": "3db1d5e13bb383e7bad051ea28ea8fc1ad6882852a1f81d87e477028b9aea54dfb49754165919b5c1f9d13686f4cac1c0a5a624dfd408fc20128fba5dcf6f02b.tgz",
+    "sha512": "3db1d5e13bb383e7bad051ea28ea8fc1ad6882852a1f81d87e477028b9aea54dfb49754165919b5c1f9d13686f4cac1c0a5a624dfd408fc20128fba5dcf6f02b"
   },
   {
     "type": "file",
@@ -1702,10 +1702,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/inspector/-/inspector-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/95",
-    "dest-filename": "9517053828182f5255f088f7fe57fba22d3dea37cee095a67e43dc3a31ee396078c8d74967feaf3452e20fe08d81fb0ec4508e721865ba38c539726a6c552742.tgz",
-    "sha512": "9517053828182f5255f088f7fe57fba22d3dea37cee095a67e43dc3a31ee396078c8d74967feaf3452e20fe08d81fb0ec4508e721865ba38c539726a6c552742"
+    "url": "https://registry.npmjs.org/@gjsify/inspector/-/inspector-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/38",
+    "dest-filename": "3839ab23436edcee6954e72fa69349808e5bbe5683fd349f26b6420854f485fe9095c106f7d32e94ad2f84f00fcb45c03e328645b6749380767d2d88c68f0ea5.tgz",
+    "sha512": "3839ab23436edcee6954e72fa69349808e5bbe5683fd349f26b6420854f485fe9095c106f7d32e94ad2f84f00fcb45c03e328645b6749380767d2d88c68f0ea5"
   },
   {
     "type": "file",
@@ -1723,10 +1723,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/message-channel/-/message-channel-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/1a",
-    "dest-filename": "1a8d89793dcf5966527b94fc0057b01a8793e9dff18750bc652d694d44ce755f6d3e0f1dc3b3cda51ba05542fc76dceabafc4c5dedf8d2b3b65b8b18811c5f6d.tgz",
-    "sha512": "1a8d89793dcf5966527b94fc0057b01a8793e9dff18750bc652d694d44ce755f6d3e0f1dc3b3cda51ba05542fc76dceabafc4c5dedf8d2b3b65b8b18811c5f6d"
+    "url": "https://registry.npmjs.org/@gjsify/message-channel/-/message-channel-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/6c",
+    "dest-filename": "6c080ce4256114a1dc1bfa26d9173ba988071138d53f5bee4a14be4f04afed66b99f856846ca7153215136f6ad8e1f19c34464f0b0013e64f32ecdde8d6cab13.tgz",
+    "sha512": "6c080ce4256114a1dc1bfa26d9173ba988071138d53f5bee4a14be4f04afed66b99f856846ca7153215136f6ad8e1f19c34464f0b0013e64f32ecdde8d6cab13"
   },
   {
     "type": "file",
@@ -1737,10 +1737,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/module/-/module-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/e2",
-    "dest-filename": "e296768c5694814a2c85d68425350ad614ce2d8cfe850be03cf8962d1c536218d7419b816d678d96c8b4e6c305b4c5129c1adb0eb8dfc70b113e9f7ebd5fca05.tgz",
-    "sha512": "e296768c5694814a2c85d68425350ad614ce2d8cfe850be03cf8962d1c536218d7419b816d678d96c8b4e6c305b4c5129c1adb0eb8dfc70b113e9f7ebd5fca05"
+    "url": "https://registry.npmjs.org/@gjsify/module/-/module-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/9f",
+    "dest-filename": "9fb86a7efa4eb45971421df041a744d250f69c55e28a91aaf11fc15285ce54051310bfc009119792e2108e40927bb1eef99748682bdc4a92d8acdae84504e5fd.tgz",
+    "sha512": "9fb86a7efa4eb45971421df041a744d250f69c55e28a91aaf11fc15285ce54051310bfc009119792e2108e40927bb1eef99748682bdc4a92d8acdae84504e5fd"
   },
   {
     "type": "file",
@@ -1765,10 +1765,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/net/-/net-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/7c",
-    "dest-filename": "7cc157b65d0a02df88114c14f93ba207bd24c988bb27cc6ee0c5110e8f5a5c8d72cc86e5097c8cc51c3f7c6b911022e9b0078938d97fe9c90894faecb7f1dff6.tgz",
-    "sha512": "7cc157b65d0a02df88114c14f93ba207bd24c988bb27cc6ee0c5110e8f5a5c8d72cc86e5097c8cc51c3f7c6b911022e9b0078938d97fe9c90894faecb7f1dff6"
+    "url": "https://registry.npmjs.org/@gjsify/net/-/net-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/98",
+    "dest-filename": "9855480dcdfc1803f3d5328d139cd13f449a715300b9c682fd8bcd42da51e884acfc489c7d6be05adf970dc918822cca4a62f67499589062a797051bc59f63b6.tgz",
+    "sha512": "9855480dcdfc1803f3d5328d139cd13f449a715300b9c682fd8bcd42da51e884acfc489c7d6be05adf970dc918822cca4a62f67499589062a797051bc59f63b6"
   },
   {
     "type": "file",
@@ -1779,10 +1779,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/node-globals/-/node-globals-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/71",
-    "dest-filename": "71199a5823a926f5e4b658bf8f92df1fd306df1c9cd8ab1b8df1d0a65c8a59ce13d99f90b8367ff5f25141ad3c5bcaf726f4352dbfb4318f7b41a933af2b431c.tgz",
-    "sha512": "71199a5823a926f5e4b658bf8f92df1fd306df1c9cd8ab1b8df1d0a65c8a59ce13d99f90b8367ff5f25141ad3c5bcaf726f4352dbfb4318f7b41a933af2b431c"
+    "url": "https://registry.npmjs.org/@gjsify/node-globals/-/node-globals-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/9d",
+    "dest-filename": "9d31948c25a05a500ba2bd23db803a60b5d0796d50eb5677be5190f814fc5dfe06f27e8e0c9939e924623f6e9c4f44d82223306d5b96e421111435b600c0bbb5.tgz",
+    "sha512": "9d31948c25a05a500ba2bd23db803a60b5d0796d50eb5677be5190f814fc5dfe06f27e8e0c9939e924623f6e9c4f44d82223306d5b96e421111435b600c0bbb5"
   },
   {
     "type": "file",
@@ -1793,10 +1793,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/node-polyfills/-/node-polyfills-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/72",
-    "dest-filename": "720560259956b16ab53a7b7b90bede1bd626360f856ab6ff4eafd6a66ceb43bd298c960221fd6d0816e669be040fce4cd9cf10033229479b8b75e1309e8f4bc3.tgz",
-    "sha512": "720560259956b16ab53a7b7b90bede1bd626360f856ab6ff4eafd6a66ceb43bd298c960221fd6d0816e669be040fce4cd9cf10033229479b8b75e1309e8f4bc3"
+    "url": "https://registry.npmjs.org/@gjsify/node-polyfills/-/node-polyfills-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/a2",
+    "dest-filename": "a281ae8c9556baff16c913c4fa0c29d2e76ba6a6868de0e901b89651c6e04061685867942ade65a715012b2b7a72f46d3bb05e5f1df998fc806ce67d5d68fe72.tgz",
+    "sha512": "a281ae8c9556baff16c913c4fa0c29d2e76ba6a6868de0e901b89651c6e04061685867942ade65a715012b2b7a72f46d3bb05e5f1df998fc806ce67d5d68fe72"
   },
   {
     "type": "file",
@@ -1807,10 +1807,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/npm-registry/-/npm-registry-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/3c",
-    "dest-filename": "3c2dae149e1b4cc784eb36e69b1761cee047887a75f9c8d297f85a6f50c47e4a74fa1955122a6b12f82d69f83a41d7303f0d94235b1f301c21d8a2922b5762bc.tgz",
-    "sha512": "3c2dae149e1b4cc784eb36e69b1761cee047887a75f9c8d297f85a6f50c47e4a74fa1955122a6b12f82d69f83a41d7303f0d94235b1f301c21d8a2922b5762bc"
+    "url": "https://registry.npmjs.org/@gjsify/npm-registry/-/npm-registry-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/00",
+    "dest-filename": "00a61e6751e058f47cf85975a129801bb206bb0f1bf9218bfda2bf64471f340d81c415a8d98d9ee38f011def5ffded632966571553bb609e11de3201a3b568c4.tgz",
+    "sha512": "00a61e6751e058f47cf85975a129801bb206bb0f1bf9218bfda2bf64471f340d81c415a8d98d9ee38f011def5ffded632966571553bb609e11de3201a3b568c4"
   },
   {
     "type": "file",
@@ -1821,10 +1821,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/os/-/os-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/49",
-    "dest-filename": "49438b721f66f6f431e9a9982194be92a4fc921c96c18ba8a1790684d56a6406ecdfdee37152bd82841342bbab80a366ca171dcede46c0a6dd8d4e80117afc88.tgz",
-    "sha512": "49438b721f66f6f431e9a9982194be92a4fc921c96c18ba8a1790684d56a6406ecdfdee37152bd82841342bbab80a366ca171dcede46c0a6dd8d4e80117afc88"
+    "url": "https://registry.npmjs.org/@gjsify/os/-/os-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/bd",
+    "dest-filename": "bd4b29a8f07ab3af99deead0ee60b1fbd330fba2e1049321b844a26b2ee32a3eb217b362353dfe74a75771da1eb721c444220f7ac1c1bbe089b32054e5b26e06.tgz",
+    "sha512": "bd4b29a8f07ab3af99deead0ee60b1fbd330fba2e1049321b844a26b2ee32a3eb217b362353dfe74a75771da1eb721c444220f7ac1c1bbe089b32054e5b26e06"
   },
   {
     "type": "file",
@@ -1835,10 +1835,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/path/-/path-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/99",
-    "dest-filename": "99a202cddfaaeb07961b2b85c33b8782aff05c51c4f4fe1cb2d7113d3b3fc34b20f9bf68befa893e34aee3801d45460776ca31e4288e190e3ee4f95caa4d5c6b.tgz",
-    "sha512": "99a202cddfaaeb07961b2b85c33b8782aff05c51c4f4fe1cb2d7113d3b3fc34b20f9bf68befa893e34aee3801d45460776ca31e4288e190e3ee4f95caa4d5c6b"
+    "url": "https://registry.npmjs.org/@gjsify/path/-/path-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/8a",
+    "dest-filename": "8a55259070155da651bb9818e3391accee0d39530c6de8633565acdbee5e4b6765d559d167782bb8235315607eed502ffee9b237741e604599e7444b7b976298.tgz",
+    "sha512": "8a55259070155da651bb9818e3391accee0d39530c6de8633565acdbee5e4b6765d559d167782bb8235315607eed502ffee9b237741e604599e7444b7b976298"
   },
   {
     "type": "file",
@@ -1849,10 +1849,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/perf_hooks/-/perf_hooks-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/3a",
-    "dest-filename": "3a9a8b3b50a05b8f3ebe982a5c7207d5a0b0c9fc86eb09f323208703ee1ade9677322a5b930aefeb2ae27beeea8b5910caf44a8bd9ba262b664e72812cdee93e.tgz",
-    "sha512": "3a9a8b3b50a05b8f3ebe982a5c7207d5a0b0c9fc86eb09f323208703ee1ade9677322a5b930aefeb2ae27beeea8b5910caf44a8bd9ba262b664e72812cdee93e"
+    "url": "https://registry.npmjs.org/@gjsify/perf_hooks/-/perf_hooks-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/8f",
+    "dest-filename": "8ff94b195c449c8ef78c1955c439a1c332a43a94c712694e11ef8c61bbd3f65d1778da114c033738f8c387f1e7238118746443e6e722181b612fd0710d58eca5.tgz",
+    "sha512": "8ff94b195c449c8ef78c1955c439a1c332a43a94c712694e11ef8c61bbd3f65d1778da114c033738f8c387f1e7238118746443e6e722181b612fd0710d58eca5"
   },
   {
     "type": "file",
@@ -1863,10 +1863,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/process/-/process-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/5d",
-    "dest-filename": "5dd691158470ae196d9f0fab2e3cac7530e10bd1d3345c04a6994874295ed513a17b7feba85a725292969d9eefae0b1b0d393aeaed262c4664a5eaf42c576a60.tgz",
-    "sha512": "5dd691158470ae196d9f0fab2e3cac7530e10bd1d3345c04a6994874295ed513a17b7feba85a725292969d9eefae0b1b0d393aeaed262c4664a5eaf42c576a60"
+    "url": "https://registry.npmjs.org/@gjsify/process/-/process-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/fe",
+    "dest-filename": "fe4752e5c2f623ce8ccdffcc9e8be4b29c9ff88bf1ac69ed2ad2d019d5329d188be8b76ec3c7111d5507681f8d5746293128a463aa14708f01bbc4bc9fa45ae8.tgz",
+    "sha512": "fe4752e5c2f623ce8ccdffcc9e8be4b29c9ff88bf1ac69ed2ad2d019d5329d188be8b76ec3c7111d5507681f8d5746293128a463aa14708f01bbc4bc9fa45ae8"
   },
   {
     "type": "file",
@@ -1877,10 +1877,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/querystring/-/querystring-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/42",
-    "dest-filename": "42930ed968a532f8beadafddf57e61bf04c97f6ad6e81df54451e371c741d62ae04f7d3bb9551e29c2d5f436ffdb09607f171fbfec8ca7c44c5b9f4dd649b66e.tgz",
-    "sha512": "42930ed968a532f8beadafddf57e61bf04c97f6ad6e81df54451e371c741d62ae04f7d3bb9551e29c2d5f436ffdb09607f171fbfec8ca7c44c5b9f4dd649b66e"
+    "url": "https://registry.npmjs.org/@gjsify/querystring/-/querystring-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/3a",
+    "dest-filename": "3a04fe708451a52fdb9f0ed02ee741e8b65d0aa28dd942df777e646f909ba7d69f9a3f2bcedadb5de985d60d2dbb29a9d425b36c1ed172deb51e1a1e73844e4d.tgz",
+    "sha512": "3a04fe708451a52fdb9f0ed02ee741e8b65d0aa28dd942df777e646f909ba7d69f9a3f2bcedadb5de985d60d2dbb29a9d425b36c1ed172deb51e1a1e73844e4d"
   },
   {
     "type": "file",
@@ -1891,10 +1891,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/readline/-/readline-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/14",
-    "dest-filename": "1485439f56bda0db8e5e274804fb5c61d4fe02dd5b1f26c86548f8b25829599bb2e1729fe6a87adc069e19cb1dabb354f6cab5ad5ebf6872d9bf309a1d7ba686.tgz",
-    "sha512": "1485439f56bda0db8e5e274804fb5c61d4fe02dd5b1f26c86548f8b25829599bb2e1729fe6a87adc069e19cb1dabb354f6cab5ad5ebf6872d9bf309a1d7ba686"
+    "url": "https://registry.npmjs.org/@gjsify/readline/-/readline-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/a2",
+    "dest-filename": "a2c25bd0ad80771f71baf13282ddcca2be0818d48d0e1b3fa2d07e1a244d9b2a80690a098dfd37d885881718a65748854f91a7460009fb5be2b9096aacbc6287.tgz",
+    "sha512": "a2c25bd0ad80771f71baf13282ddcca2be0818d48d0e1b3fa2d07e1a244d9b2a80690a098dfd37d885881718a65748854f91a7460009fb5be2b9096aacbc6287"
   },
   {
     "type": "file",
@@ -1912,10 +1912,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/resolve-npm/-/resolve-npm-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/d0",
-    "dest-filename": "d0f88418487e21ec995b44199f9c548497e14d93a0ee45fda52dd097280e9d889b241cd85f880614a7e2ac772fe604ed25a032323ce2968fa631d43aafb19642.tgz",
-    "sha512": "d0f88418487e21ec995b44199f9c548497e14d93a0ee45fda52dd097280e9d889b241cd85f880614a7e2ac772fe604ed25a032323ce2968fa631d43aafb19642"
+    "url": "https://registry.npmjs.org/@gjsify/resolve-npm/-/resolve-npm-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/9c",
+    "dest-filename": "9ccf91f135c025370ea854a8df691bdad88bc8a1f8be3990d7d64448e2b54150f0d0af52aed798fab18f07ace3e5ad0bffc4bacb611693f090658ef5d85d8fd7.tgz",
+    "sha512": "9ccf91f135c025370ea854a8df691bdad88bc8a1f8be3990d7d64448e2b54150f0d0af52aed798fab18f07ace3e5ad0bffc4bacb611693f090658ef5d85d8fd7"
   },
   {
     "type": "file",
@@ -1940,10 +1940,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/rolldown-plugin-deepkit/-/rolldown-plugin-deepkit-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/fc",
-    "dest-filename": "fc803808654b6db6a34e5895d157aa10869dadced76a20ab19b403f7750e7ba5a9d8181d4e8bf79364e844fe04c5f9da2fbb4c27b542b05f29e10d6382f8fccd.tgz",
-    "sha512": "fc803808654b6db6a34e5895d157aa10869dadced76a20ab19b403f7750e7ba5a9d8181d4e8bf79364e844fe04c5f9da2fbb4c27b542b05f29e10d6382f8fccd"
+    "url": "https://registry.npmjs.org/@gjsify/rolldown-plugin-deepkit/-/rolldown-plugin-deepkit-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/b2",
+    "dest-filename": "b2ba322150b6f5e3a0471b8fb59665186590502abb30d226a4c6c4e37b9d94a5b960e8628292eb4ef2f0b57c47dbd3b9ec6c112bdbfe8dcabcacacc64b0c313f.tgz",
+    "sha512": "b2ba322150b6f5e3a0471b8fb59665186590502abb30d226a4c6c4e37b9d94a5b960e8628292eb4ef2f0b57c47dbd3b9ec6c112bdbfe8dcabcacacc64b0c313f"
   },
   {
     "type": "file",
@@ -1961,10 +1961,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/rolldown-plugin-gjsify/-/rolldown-plugin-gjsify-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/95",
-    "dest-filename": "954cc5075857e3b9609905ddd73fa753ffe21a4b54258615bb47930403c2f4038c542469f05b1ee6cea77622dc817d1a66eae57fbf7ddc6f59c79e5e246ab4fa.tgz",
-    "sha512": "954cc5075857e3b9609905ddd73fa753ffe21a4b54258615bb47930403c2f4038c542469f05b1ee6cea77622dc817d1a66eae57fbf7ddc6f59c79e5e246ab4fa"
+    "url": "https://registry.npmjs.org/@gjsify/rolldown-plugin-gjsify/-/rolldown-plugin-gjsify-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/df",
+    "dest-filename": "dff4648789f57758204f0b4154837a51d4420389ff52185e741bfffc7491d1dfa1f0fc99f0a83c8bee02262f0c269d30b2d24990006d38dd5f0e6292f6eda944.tgz",
+    "sha512": "dff4648789f57758204f0b4154837a51d4420389ff52185e741bfffc7491d1dfa1f0fc99f0a83c8bee02262f0c269d30b2d24990006d38dd5f0e6292f6eda944"
   },
   {
     "type": "file",
@@ -1982,10 +1982,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/rolldown-plugin-pnp/-/rolldown-plugin-pnp-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/48",
-    "dest-filename": "4813e35d260eccfecc972e33a0a1de7f370601b8037b6ad30dd281463b0182ab8ab01702bdc90580aaef88b050a73d7d6c66095ad4eb0a00d3f31100efe5040a.tgz",
-    "sha512": "4813e35d260eccfecc972e33a0a1de7f370601b8037b6ad30dd281463b0182ab8ab01702bdc90580aaef88b050a73d7d6c66095ad4eb0a00d3f31100efe5040a"
+    "url": "https://registry.npmjs.org/@gjsify/rolldown-plugin-pnp/-/rolldown-plugin-pnp-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/97",
+    "dest-filename": "970c911403da5c6e1ca2a895e4133b6c487c8befcfaee1edee0b64719733c762bd4e586ec0be5f7d50d5f289e1e1fd5ded173012558420b51b98cedb73ca7882.tgz",
+    "sha512": "970c911403da5c6e1ca2a895e4133b6c487c8befcfaee1edee0b64719733c762bd4e586ec0be5f7d50d5f289e1e1fd5ded173012558420b51b98cedb73ca7882"
   },
   {
     "type": "file",
@@ -1996,10 +1996,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/sab-native/-/sab-native-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/81",
-    "dest-filename": "81f24b73e30136d549e3970ad5679944c742a9f14463980d166f9e70b1caa5e5ad05994601b0a175afb8eda587eb6e3529bb678a12b5ac44a3d24566f2ebd48f.tgz",
-    "sha512": "81f24b73e30136d549e3970ad5679944c742a9f14463980d166f9e70b1caa5e5ad05994601b0a175afb8eda587eb6e3529bb678a12b5ac44a3d24566f2ebd48f"
+    "url": "https://registry.npmjs.org/@gjsify/sab-native/-/sab-native-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/8f",
+    "dest-filename": "8f37cd2329fdaa5f7397e328c31b5c5c6f4aec8e6913bceacf145a01194125af3794f6212a9bb749b079f7bf15cf0d9caaec2a05c8433e7e7b56241d3ec9c5c9.tgz",
+    "sha512": "8f37cd2329fdaa5f7397e328c31b5c5c6f4aec8e6913bceacf145a01194125af3794f6212a9bb749b079f7bf15cf0d9caaec2a05c8433e7e7b56241d3ec9c5c9"
   },
   {
     "type": "file",
@@ -2010,10 +2010,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/semver/-/semver-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/6e",
-    "dest-filename": "6e9a553dd42b29737d4f7c111b9c9f95359b4fe02d6550a4694342aaa40f3ce44a55fe7b8199dad4a34a1baec65a002e7a2bed61c838a9c88f4563bf28943f65.tgz",
-    "sha512": "6e9a553dd42b29737d4f7c111b9c9f95359b4fe02d6550a4694342aaa40f3ce44a55fe7b8199dad4a34a1baec65a002e7a2bed61c838a9c88f4563bf28943f65"
+    "url": "https://registry.npmjs.org/@gjsify/semver/-/semver-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/fb",
+    "dest-filename": "fbe81e31799f1e12450c6a02d8ec585fc2528c4dd5604a0cda3587672111a2fb0af3d1f555d44de21855b7903589cd89e89b5986bb61f9010fbdb4ebfa9a8665.tgz",
+    "sha512": "fbe81e31799f1e12450c6a02d8ec585fc2528c4dd5604a0cda3587672111a2fb0af3d1f555d44de21855b7903589cd89e89b5986bb61f9010fbdb4ebfa9a8665"
   },
   {
     "type": "file",
@@ -2024,10 +2024,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/sqlite/-/sqlite-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/48",
-    "dest-filename": "4861da47dbd0e6f127b02fdead74f27752e8be9dd033ddce8d26925c8eca2b5b3a7ed78015520fa035a170818776fff5b7f732b65255b7e0a9e75948f0fb3a83.tgz",
-    "sha512": "4861da47dbd0e6f127b02fdead74f27752e8be9dd033ddce8d26925c8eca2b5b3a7ed78015520fa035a170818776fff5b7f732b65255b7e0a9e75948f0fb3a83"
+    "url": "https://registry.npmjs.org/@gjsify/sqlite/-/sqlite-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/03",
+    "dest-filename": "030d81e320548d39b890742a371019cc642eb3a3e6a44fbbfce9835fe563eff5536188e091a5cddb5e1406b83ed4176c91d84704583bedc545799a5d75b8396f.tgz",
+    "sha512": "030d81e320548d39b890742a371019cc642eb3a3e6a44fbbfce9835fe563eff5536188e091a5cddb5e1406b83ed4176c91d84704583bedc545799a5d75b8396f"
   },
   {
     "type": "file",
@@ -2052,10 +2052,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/28",
-    "dest-filename": "2859bd1ffeae2e6990a0fb4c008f72f4eaf868b8a9d2a7f6e25431534c034ee20471b307a5737dbdce1f1c3af3e50834dc27df91fbc7ce1da303c443410f40ea.tgz",
-    "sha512": "2859bd1ffeae2e6990a0fb4c008f72f4eaf868b8a9d2a7f6e25431534c034ee20471b307a5737dbdce1f1c3af3e50834dc27df91fbc7ce1da303c443410f40ea"
+    "url": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/8e",
+    "dest-filename": "8e4d837ce28c74e3e953e3e3ab9404eaaafdc55ad0dde5ec7a916dc0b83f706600c46ef1c3fd3fb48f414a29cf55417e3c112c15a5fe63a8f3d87428909b22b9.tgz",
+    "sha512": "8e4d837ce28c74e3e953e3e3ab9404eaaafdc55ad0dde5ec7a916dc0b83f706600c46ef1c3fd3fb48f414a29cf55417e3c112c15a5fe63a8f3d87428909b22b9"
   },
   {
     "type": "file",
@@ -2066,10 +2066,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/string_decoder/-/string_decoder-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/08",
-    "dest-filename": "0895ab8b967f352427e63c9abfc49de04c0ecc8bb96bb5958e8d9cd453d6555cdfb5101b941791808d1dfd5e3f87ed1a837175f526ad1bd96003a736d39672c4.tgz",
-    "sha512": "0895ab8b967f352427e63c9abfc49de04c0ecc8bb96bb5958e8d9cd453d6555cdfb5101b941791808d1dfd5e3f87ed1a837175f526ad1bd96003a736d39672c4"
+    "url": "https://registry.npmjs.org/@gjsify/string_decoder/-/string_decoder-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/ea",
+    "dest-filename": "ea59c737faceef2f822e988f3bac30068ff2a88baf2383ac780b28907d0279c1f6096394e64d311f01cb3cec858b2269b45777bd7d8cbe08333596b3c7fc2293.tgz",
+    "sha512": "ea59c737faceef2f822e988f3bac30068ff2a88baf2383ac780b28907d0279c1f6096394e64d311f01cb3cec858b2269b45777bd7d8cbe08333596b3c7fc2293"
   },
   {
     "type": "file",
@@ -2080,10 +2080,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/sys/-/sys-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/39",
-    "dest-filename": "3915ffd055468356b212ab90f7723ffee8f4d23f35bac8fc9ed8418eb6efc3768f75e6c66e9a52bdaa21978fdf3f2bd5f55dbc98223a8254ffb611afd589dc80.tgz",
-    "sha512": "3915ffd055468356b212ab90f7723ffee8f4d23f35bac8fc9ed8418eb6efc3768f75e6c66e9a52bdaa21978fdf3f2bd5f55dbc98223a8254ffb611afd589dc80"
+    "url": "https://registry.npmjs.org/@gjsify/sys/-/sys-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/6a",
+    "dest-filename": "6aeb82d1d5e2fdfbceeecd452b4da5628edacac86f8ed6e4d31301fa693294264560c7ebe13e930d96d7447c83cf45f1898240652c5cd9dd6d637fc6206262ed.tgz",
+    "sha512": "6aeb82d1d5e2fdfbceeecd452b4da5628edacac86f8ed6e4d31301fa693294264560c7ebe13e930d96d7447c83cf45f1898240652c5cd9dd6d637fc6206262ed"
   },
   {
     "type": "file",
@@ -2094,10 +2094,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/tar/-/tar-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/1b",
-    "dest-filename": "1b701b82be3ada0128e05bcddcb1380033de797e98f4b68169ed9d0feac32c0aa73dabdf905fea6a18af96cc1d793562845b2151cb18723898655b86fc327392.tgz",
-    "sha512": "1b701b82be3ada0128e05bcddcb1380033de797e98f4b68169ed9d0feac32c0aa73dabdf905fea6a18af96cc1d793562845b2151cb18723898655b86fc327392"
+    "url": "https://registry.npmjs.org/@gjsify/tar/-/tar-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/ea",
+    "dest-filename": "ea40b2499426b5aa9366fe2453e2a50934649d0d47019a8ac33e838897aff52fedf906b22c2721880b300450f1face90a3d53ed2c1eeb31cecbf31e9186be620.tgz",
+    "sha512": "ea40b2499426b5aa9366fe2453e2a50934649d0d47019a8ac33e838897aff52fedf906b22c2721880b300450f1face90a3d53ed2c1eeb31cecbf31e9186be620"
   },
   {
     "type": "file",
@@ -2108,10 +2108,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/terminal-native/-/terminal-native-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/d2",
-    "dest-filename": "d25c1589d78b0b42addb6ebe38f8c885767fcba51aa67e618f49a6bc5ac7f7b2e21f127d60e2246dac64e35d0209f55a1c76e94d45c9ffc13247829bf965e54d.tgz",
-    "sha512": "d25c1589d78b0b42addb6ebe38f8c885767fcba51aa67e618f49a6bc5ac7f7b2e21f127d60e2246dac64e35d0209f55a1c76e94d45c9ffc13247829bf965e54d"
+    "url": "https://registry.npmjs.org/@gjsify/terminal-native/-/terminal-native-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/e8",
+    "dest-filename": "e84d13a309c2eba2a1815ff970a809e06fe573b5ab4a6f854d445ad0389a24a6e6f0a7f6929398a36f79659ff6ab4bcdc14d7e3188e7e6153c11c82c9a1b8f4b.tgz",
+    "sha512": "e84d13a309c2eba2a1815ff970a809e06fe573b5ab4a6f854d445ad0389a24a6e6f0a7f6929398a36f79659ff6ab4bcdc14d7e3188e7e6153c11c82c9a1b8f4b"
   },
   {
     "type": "file",
@@ -2122,10 +2122,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/timers/-/timers-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/fd",
-    "dest-filename": "fd683bc44c7cb3a980d28da58b8b146446200e80944fa4ce88c6b0e526838792061fed4762cbb82e77d15740d0b5c6c18ffa222f8ef90fe5078281c95ea1f3d1.tgz",
-    "sha512": "fd683bc44c7cb3a980d28da58b8b146446200e80944fa4ce88c6b0e526838792061fed4762cbb82e77d15740d0b5c6c18ffa222f8ef90fe5078281c95ea1f3d1"
+    "url": "https://registry.npmjs.org/@gjsify/timers/-/timers-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/62",
+    "dest-filename": "62023502d35fa5cb819592d4a6f712959f572d64b771af1eb152d6b971fc4f0d6765aa2956e232397b4e52e141486026e4955cd13c814adca468ac0e3d4f61a4.tgz",
+    "sha512": "62023502d35fa5cb819592d4a6f712959f572d64b771af1eb152d6b971fc4f0d6765aa2956e232397b4e52e141486026e4955cd13c814adca468ac0e3d4f61a4"
   },
   {
     "type": "file",
@@ -2136,10 +2136,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/tls-native/-/tls-native-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/cb",
-    "dest-filename": "cb7b024e824a1ee7fada3faacec4c4f37e2e8c5f8b9b8273cd8d4e79a2a82feb1caa473b8806373b06ad0fa9f4e5424fa27e22296e796091c65633d91528533a.tgz",
-    "sha512": "cb7b024e824a1ee7fada3faacec4c4f37e2e8c5f8b9b8273cd8d4e79a2a82feb1caa473b8806373b06ad0fa9f4e5424fa27e22296e796091c65633d91528533a"
+    "url": "https://registry.npmjs.org/@gjsify/tls-native/-/tls-native-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/e4",
+    "dest-filename": "e489b3593d3b1877cbe68cb45c05baf838ac6061e91d3184d08f299935084303a9c42efa67690bd073a469ace56c7bf70d27ce2a1039c63a3f7a40ca505def66.tgz",
+    "sha512": "e489b3593d3b1877cbe68cb45c05baf838ac6061e91d3184d08f299935084303a9c42efa67690bd073a469ace56c7bf70d27ce2a1039c63a3f7a40ca505def66"
   },
   {
     "type": "file",
@@ -2150,10 +2150,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/tls/-/tls-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/cf",
-    "dest-filename": "cfc9773880b390b7384dd0ab75a68f8fe15532642f2f9eea326de07a4bc186922a31dc94e01325ae54ffeb9fffcbf9ac61940b1021c7cc3ac3e064160e64dfbc.tgz",
-    "sha512": "cfc9773880b390b7384dd0ab75a68f8fe15532642f2f9eea326de07a4bc186922a31dc94e01325ae54ffeb9fffcbf9ac61940b1021c7cc3ac3e064160e64dfbc"
+    "url": "https://registry.npmjs.org/@gjsify/tls/-/tls-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/1b",
+    "dest-filename": "1b1bef9b334766b769ef08e89b9202dc2559ed4194899ca282ce943ba795f51c1bd6e90081c55b20fb6db39ea7e0b821816e5ad41646b0a891a7cad28d571fba.tgz",
+    "sha512": "1b1bef9b334766b769ef08e89b9202dc2559ed4194899ca282ce943ba795f51c1bd6e90081c55b20fb6db39ea7e0b821816e5ad41646b0a891a7cad28d571fba"
   },
   {
     "type": "file",
@@ -2164,10 +2164,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/tsc/-/tsc-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/9b",
-    "dest-filename": "9b96b0aa426685cd8673f525ccede550c544b87b0133c878319d998ee2cd116863fbc889c7f11c96b4dc5bc62f876ac6490b39d20c4e46372144315dfb532b9a.tgz",
-    "sha512": "9b96b0aa426685cd8673f525ccede550c544b87b0133c878319d998ee2cd116863fbc889c7f11c96b4dc5bc62f876ac6490b39d20c4e46372144315dfb532b9a"
+    "url": "https://registry.npmjs.org/@gjsify/tsc/-/tsc-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/75",
+    "dest-filename": "756c12d970924490bc4dcf992f97d4b59715e510fa82d0393b04400f277a3cdb7fbc69a36b85e1d012ba6350b9136ab2c9e7218fa6a9f9f3159517f0ae24b4cf.tgz",
+    "sha512": "756c12d970924490bc4dcf992f97d4b59715e510fa82d0393b04400f277a3cdb7fbc69a36b85e1d012ba6350b9136ab2c9e7218fa6a9f9f3159517f0ae24b4cf"
   },
   {
     "type": "file",
@@ -2178,10 +2178,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/tty/-/tty-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/d3",
-    "dest-filename": "d3d058abf5ec2dcf2e1bb4f6c3c8ba5a1d636e3cf8b64cdd09f1dbe545d526dc549d4a2cc2aec528c467d44609bad8a5e54a8a3211a028986863d28bc9a67242.tgz",
-    "sha512": "d3d058abf5ec2dcf2e1bb4f6c3c8ba5a1d636e3cf8b64cdd09f1dbe545d526dc549d4a2cc2aec528c467d44609bad8a5e54a8a3211a028986863d28bc9a67242"
+    "url": "https://registry.npmjs.org/@gjsify/tty/-/tty-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/c6",
+    "dest-filename": "c690ace7616a32619f979c01f9078694862d41fd0d2b2f9a1f7f5c2c67dcf5f81a9b1011c448a202526235a631c86bc5640eeb82be209112679263634b57d857.tgz",
+    "sha512": "c690ace7616a32619f979c01f9078694862d41fd0d2b2f9a1f7f5c2c67dcf5f81a9b1011c448a202526235a631c86bc5640eeb82be209112679263634b57d857"
   },
   {
     "type": "file",
@@ -2192,10 +2192,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/url/-/url-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/f9",
-    "dest-filename": "f9e9f001550530b32b71af6ca40dac8c771926e1cb58c48ba86e53b8b45ba4d70a0219d4c6400ad6f111675d2b8fc63d268eb7f58faad2df6fa94c4747eb0a9a.tgz",
-    "sha512": "f9e9f001550530b32b71af6ca40dac8c771926e1cb58c48ba86e53b8b45ba4d70a0219d4c6400ad6f111675d2b8fc63d268eb7f58faad2df6fa94c4747eb0a9a"
+    "url": "https://registry.npmjs.org/@gjsify/url/-/url-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/ee",
+    "dest-filename": "ee836de93601402cca71fffb0fcbf69c1ab0fc3f9ad2bcee4352788c84ea3bf9c76105c6b78a15ed168b6bbb02e841cd6a88f497db1428f3f720c866dbe44d37.tgz",
+    "sha512": "ee836de93601402cca71fffb0fcbf69c1ab0fc3f9ad2bcee4352788c84ea3bf9c76105c6b78a15ed168b6bbb02e841cd6a88f497db1428f3f720c866dbe44d37"
   },
   {
     "type": "file",
@@ -2206,10 +2206,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/util/-/util-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/48",
-    "dest-filename": "48c219a71e982fb63d88ab604ff765eaf105ede1005cb93e711fe83a65161eef2f0ff3d73adce56ea74f5134e7dbf00bd69833cc15f193ab61335f3450fa3679.tgz",
-    "sha512": "48c219a71e982fb63d88ab604ff765eaf105ede1005cb93e711fe83a65161eef2f0ff3d73adce56ea74f5134e7dbf00bd69833cc15f193ab61335f3450fa3679"
+    "url": "https://registry.npmjs.org/@gjsify/util/-/util-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/e4",
+    "dest-filename": "e46869bd79ae9a372b3d475a1624378882f01b4d11c172e5a5f732828b1368156e5b4c0ad22dda5173bd1f5ffac6bcd641b53920bc2d773fc543ed1c8a8323de.tgz",
+    "sha512": "e46869bd79ae9a372b3d475a1624378882f01b4d11c172e5a5f732828b1368156e5b4c0ad22dda5173bd1f5ffac6bcd641b53920bc2d773fc543ed1c8a8323de"
   },
   {
     "type": "file",
@@ -2220,10 +2220,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/b7",
-    "dest-filename": "b7c3d7796b7a433f19153d75ebb65de9bc9effbf3802c837cd2b868aa32fd52cef3bb094febb2f67587ffe95f139efe48c6a68873e7d60d2dbc5ab77346dcec1.tgz",
-    "sha512": "b7c3d7796b7a433f19153d75ebb65de9bc9effbf3802c837cd2b868aa32fd52cef3bb094febb2f67587ffe95f139efe48c6a68873e7d60d2dbc5ab77346dcec1"
+    "url": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/a6",
+    "dest-filename": "a6a6ee490ccf22974a5de26d6ceeabec43b11031eb818ca31494ca05c2867d4fe5c1ef830e4ced3402294f60eb563ae0b1a2141752b0c9174880ed1c484ded00.tgz",
+    "sha512": "a6a6ee490ccf22974a5de26d6ceeabec43b11031eb818ca31494ca05c2867d4fe5c1ef830e4ced3402294f60eb563ae0b1a2141752b0c9174880ed1c484ded00"
   },
   {
     "type": "file",
@@ -2234,10 +2234,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/v8/-/v8-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/17",
-    "dest-filename": "177b391113a46d74cce6a2ddadeee0592de94868a6196cc4cc36e888f896d276319831f63ec86222147f66828870bcca3c60503e8d430762c50a80ee6b0be3d2.tgz",
-    "sha512": "177b391113a46d74cce6a2ddadeee0592de94868a6196cc4cc36e888f896d276319831f63ec86222147f66828870bcca3c60503e8d430762c50a80ee6b0be3d2"
+    "url": "https://registry.npmjs.org/@gjsify/v8/-/v8-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/39",
+    "dest-filename": "3958331ff1f338e34d146792fc85b00769e482a88d0bbb73559539e192aeb46e4b3a22669f0349b4231943fdb3d8488bceac27c3329eac7268a725af1adb0738.tgz",
+    "sha512": "3958331ff1f338e34d146792fc85b00769e482a88d0bbb73559539e192aeb46e4b3a22669f0349b4231943fdb3d8488bceac27c3329eac7268a725af1adb0738"
   },
   {
     "type": "file",
@@ -2255,10 +2255,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/vite-plugin-blueprint/-/vite-plugin-blueprint-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/c5",
-    "dest-filename": "c58c898eb42ce06d3433c10ae69942337e54d69bd60b2820aee00c14935934049c946cc3558e7f3f917995ad6fa47b0b468ccee2b932a6e47c18d6b1a24d26f5.tgz",
-    "sha512": "c58c898eb42ce06d3433c10ae69942337e54d69bd60b2820aee00c14935934049c946cc3558e7f3f917995ad6fa47b0b468ccee2b932a6e47c18d6b1a24d26f5"
+    "url": "https://registry.npmjs.org/@gjsify/vite-plugin-blueprint/-/vite-plugin-blueprint-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/f2",
+    "dest-filename": "f2dd9f6dd61a44b20809d565665600abead29f17b7753642ce7d02c6c9fa16ccfd6bad728e914efcd88984687cccff9be394c36e95b30719af1ceb8aa142c63f.tgz",
+    "sha512": "f2dd9f6dd61a44b20809d565665600abead29f17b7753642ce7d02c6c9fa16ccfd6bad728e914efcd88984687cccff9be394c36e95b30719af1ceb8aa142c63f"
   },
   {
     "type": "file",
@@ -2276,10 +2276,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/vite-plugin-gjsify/-/vite-plugin-gjsify-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/1d",
-    "dest-filename": "1d588139af593d003b70d40383b78b33faa0a14a0d54737bc2abab735f3b7746968ca7d59ea373ba974c0ea5840a142cf17c310f56ec12e929909e58d59fa419.tgz",
-    "sha512": "1d588139af593d003b70d40383b78b33faa0a14a0d54737bc2abab735f3b7746968ca7d59ea373ba974c0ea5840a142cf17c310f56ec12e929909e58d59fa419"
+    "url": "https://registry.npmjs.org/@gjsify/vite-plugin-gjsify/-/vite-plugin-gjsify-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/14",
+    "dest-filename": "14ba7b3a3bbcbe54f2e996087460642eb04248df2b52704aa47c7c3a4941daed5b388e985bba0885349893486920908fb1b15cffc8f948c89092fffcabc8d91d.tgz",
+    "sha512": "14ba7b3a3bbcbe54f2e996087460642eb04248df2b52704aa47c7c3a4941daed5b388e985bba0885349893486920908fb1b15cffc8f948c89092fffcabc8d91d"
   },
   {
     "type": "file",
@@ -2290,10 +2290,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/vm/-/vm-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/fc",
-    "dest-filename": "fcbf1af07fd18f51d136cc4b8b3943862227d29cf202d1df97e76f68537f0ef5b83a8240c37327ca7975794b0782b51bfe2581fcbd4a3e1fdcd689fa857025dd.tgz",
-    "sha512": "fcbf1af07fd18f51d136cc4b8b3943862227d29cf202d1df97e76f68537f0ef5b83a8240c37327ca7975794b0782b51bfe2581fcbd4a3e1fdcd689fa857025dd"
+    "url": "https://registry.npmjs.org/@gjsify/vm/-/vm-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/dd",
+    "dest-filename": "ddead63a2e9bcf35bb8f88da30e797ee1874484287cf592acf25c2bd7a6e5becac8cf0f2dd359b538546b451cba466797cefc41ebe6184a5760f0b001d1610d9.tgz",
+    "sha512": "ddead63a2e9bcf35bb8f88da30e797ee1874484287cf592acf25c2bd7a6e5becac8cf0f2dd359b538546b451cba466797cefc41ebe6184a5760f0b001d1610d9"
   },
   {
     "type": "file",
@@ -2304,10 +2304,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/web-globals/-/web-globals-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/7d",
-    "dest-filename": "7dbde0e18e7fbd1500fcdc8b8e246b3e3e0ded4cf031582a63fab8ef25bf3923e523e2e9b3f4cdd87fe0fff98741271f814061dc13a3d5d516f8cfcf217831c8.tgz",
-    "sha512": "7dbde0e18e7fbd1500fcdc8b8e246b3e3e0ded4cf031582a63fab8ef25bf3923e523e2e9b3f4cdd87fe0fff98741271f814061dc13a3d5d516f8cfcf217831c8"
+    "url": "https://registry.npmjs.org/@gjsify/web-globals/-/web-globals-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/46",
+    "dest-filename": "46de432846e204b63f2735c2ec0950fa79ea250c35a6dae2df074534a51aa5ed08e4a1c9ade0977e57e4af2416a605676283ca30e8c846d7c1d29af33e8e2c39.tgz",
+    "sha512": "46de432846e204b63f2735c2ec0950fa79ea250c35a6dae2df074534a51aa5ed08e4a1c9ade0977e57e4af2416a605676283ca30e8c846d7c1d29af33e8e2c39"
   },
   {
     "type": "file",
@@ -2318,10 +2318,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/web-polyfills/-/web-polyfills-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/e6",
-    "dest-filename": "e66be95150f8aa3c55f6f4f24e12d045a7fdc0f0da2eab025e1146c0c720c8ed39dfa53c25c304929e9fd7e181de65c0e3b5dee85c609e16e4232e949513737e.tgz",
-    "sha512": "e66be95150f8aa3c55f6f4f24e12d045a7fdc0f0da2eab025e1146c0c720c8ed39dfa53c25c304929e9fd7e181de65c0e3b5dee85c609e16e4232e949513737e"
+    "url": "https://registry.npmjs.org/@gjsify/web-polyfills/-/web-polyfills-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/48",
+    "dest-filename": "484ddb854d8b7d2e9731d2d41fd6022930549a26bfe3d178ff32bd9674fcd0ff2349fb06eb366ed5799397cc041a2012230d06dadc586ed957894e113ebc39eb.tgz",
+    "sha512": "484ddb854d8b7d2e9731d2d41fd6022930549a26bfe3d178ff32bd9674fcd0ff2349fb06eb366ed5799397cc041a2012230d06dadc586ed957894e113ebc39eb"
   },
   {
     "type": "file",
@@ -2332,10 +2332,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/94",
-    "dest-filename": "9419a763fe0889b4fc8a01a6cbf22bb5c650ad0c59bd6e3d723c27209d13cb41aba5581683ef2bd98137f222e3f8175560c86df061513de996b9d46a24a37693.tgz",
-    "sha512": "9419a763fe0889b4fc8a01a6cbf22bb5c650ad0c59bd6e3d723c27209d13cb41aba5581683ef2bd98137f222e3f8175560c86df061513de996b9d46a24a37693"
+    "url": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/2f",
+    "dest-filename": "2fe4d06b4336acd9ef390cafa01ee8c3bdc3131e63f051632aa341d2ca8844a6f360988d5ef1d79e04dc1a31e53ca0c7981b7018bdf884106e514cd0ccb67d1a.tgz",
+    "sha512": "2fe4d06b4336acd9ef390cafa01ee8c3bdc3131e63f051632aa341d2ca8844a6f360988d5ef1d79e04dc1a31e53ca0c7981b7018bdf884106e514cd0ccb67d1a"
   },
   {
     "type": "file",
@@ -2346,10 +2346,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/webassembly/-/webassembly-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/48",
-    "dest-filename": "48185132b456400fbbb5a2331c3c8e46e18fe0dcb380fb6db4325d3d8868150d86647f73801711efec23d04e816a4cddc3d51685735fc556b53d9b1bba8ffbc8.tgz",
-    "sha512": "48185132b456400fbbb5a2331c3c8e46e18fe0dcb380fb6db4325d3d8868150d86647f73801711efec23d04e816a4cddc3d51685735fc556b53d9b1bba8ffbc8"
+    "url": "https://registry.npmjs.org/@gjsify/webassembly/-/webassembly-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/51",
+    "dest-filename": "5124c7a0e3b3e6fcc83931f0112ddd6e2f49dd7ce532d51d80e58e89729ea2c25492f5af536dcb83be84b5b2f2390868e3a1f2c651a156e61c82246d5a5f1570.tgz",
+    "sha512": "5124c7a0e3b3e6fcc83931f0112ddd6e2f49dd7ce532d51d80e58e89729ea2c25492f5af536dcb83be84b5b2f2390868e3a1f2c651a156e61c82246d5a5f1570"
   },
   {
     "type": "file",
@@ -2360,10 +2360,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/webaudio/-/webaudio-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/5e",
-    "dest-filename": "5e2932e685ee4d0fa402bc49019b48b46f82103c8bc530d24f653fcf5b4bdcfc76e47ecf37e77c2011866d4e0cb12c07072246da4bbe92ff0bb1af734dd58e68.tgz",
-    "sha512": "5e2932e685ee4d0fa402bc49019b48b46f82103c8bc530d24f653fcf5b4bdcfc76e47ecf37e77c2011866d4e0cb12c07072246da4bbe92ff0bb1af734dd58e68"
+    "url": "https://registry.npmjs.org/@gjsify/webaudio/-/webaudio-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/24",
+    "dest-filename": "243bef0cfcaba60000ddb5c84cad57194a2cd6a39a3230485f5970c704cdf0eab51470264d9ec5d9349e3274e7127a6fe723d02f83adfc70db8b25565c1b46a2.tgz",
+    "sha512": "243bef0cfcaba60000ddb5c84cad57194a2cd6a39a3230485f5970c704cdf0eab51470264d9ec5d9349e3274e7127a6fe723d02f83adfc70db8b25565c1b46a2"
   },
   {
     "type": "file",
@@ -2374,10 +2374,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/webcrypto/-/webcrypto-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/1a",
-    "dest-filename": "1afd6c676de61148d5d69c447dde401a909454e54c36de9d7dd286059c90c3208ce323b0f36e1ac1f8b4c630439741f783b0bad2ffac1c2807df5a11fa74589d.tgz",
-    "sha512": "1afd6c676de61148d5d69c447dde401a909454e54c36de9d7dd286059c90c3208ce323b0f36e1ac1f8b4c630439741f783b0bad2ffac1c2807df5a11fa74589d"
+    "url": "https://registry.npmjs.org/@gjsify/webcrypto/-/webcrypto-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/83",
+    "dest-filename": "83532f4acf2e460d25f495716b9253ef1899e19f48dbf40cd514ca9c1a1d1994a69db164f4a9b230a1eee6d3e15ed8498e5345a5cb4c6ce578212889cb4975e3.tgz",
+    "sha512": "83532f4acf2e460d25f495716b9253ef1899e19f48dbf40cd514ca9c1a1d1994a69db164f4a9b230a1eee6d3e15ed8498e5345a5cb4c6ce578212889cb4975e3"
   },
   {
     "type": "file",
@@ -2388,10 +2388,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/websocket/-/websocket-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/2f",
-    "dest-filename": "2f1c180896c1bdb1c77daeaa94837dd9c9270fd9b196fa6de439a51fa7c0abb2522e52ffc28b94b71c36228bc06d681a808c2a6c731a41f90bd86e5633f2a34d.tgz",
-    "sha512": "2f1c180896c1bdb1c77daeaa94837dd9c9270fd9b196fa6de439a51fa7c0abb2522e52ffc28b94b71c36228bc06d681a808c2a6c731a41f90bd86e5633f2a34d"
+    "url": "https://registry.npmjs.org/@gjsify/websocket/-/websocket-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/36",
+    "dest-filename": "363ab467d39e7ce1d7017986bf8f7c9d3576777bae3bb7a1daf4e311dbcc780f65ec98c5fac96a46ed38607d1a8f2a196672cd935c822e2de2679be52d8dfd28.tgz",
+    "sha512": "363ab467d39e7ce1d7017986bf8f7c9d3576777bae3bb7a1daf4e311dbcc780f65ec98c5fac96a46ed38607d1a8f2a196672cd935c822e2de2679be52d8dfd28"
   },
   {
     "type": "file",
@@ -2402,10 +2402,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/webstorage/-/webstorage-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/63",
-    "dest-filename": "63996ad850ae39064796bcc6455c07664a4674edbb171052d82f0535392918ef3c79054084301abe26faa80e7b24598aa79ca4c458e8c2327848e9d859e6b635.tgz",
-    "sha512": "63996ad850ae39064796bcc6455c07664a4674edbb171052d82f0535392918ef3c79054084301abe26faa80e7b24598aa79ca4c458e8c2327848e9d859e6b635"
+    "url": "https://registry.npmjs.org/@gjsify/webstorage/-/webstorage-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/64",
+    "dest-filename": "645d446a196d610d253a0c16c1b16e6b2948284f057185714d72b0562980a7d5c7c3d711a2db13df872f3da208abb71036184173f9f7b3ae1a92a042731c29bf.tgz",
+    "sha512": "645d446a196d610d253a0c16c1b16e6b2948284f057185714d72b0562980a7d5c7c3d711a2db13df872f3da208abb71036184173f9f7b3ae1a92a042731c29bf"
   },
   {
     "type": "file",
@@ -2416,10 +2416,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/worker_threads/-/worker_threads-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/98",
-    "dest-filename": "98547c5e054d87a0c839346f4247e6fdff018dd474c1be9de6c2233051a6af678d36539bd9a4e8ec69eada78757822ffc0de2821d05da2bcde77c1f432e03d2b.tgz",
-    "sha512": "98547c5e054d87a0c839346f4247e6fdff018dd474c1be9de6c2233051a6af678d36539bd9a4e8ec69eada78757822ffc0de2821d05da2bcde77c1f432e03d2b"
+    "url": "https://registry.npmjs.org/@gjsify/worker_threads/-/worker_threads-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/eb",
+    "dest-filename": "eb4d373db53ebc25c8d1401b0469a78c6e22cc1d163bba8d0a08eb2bb24773fb9160fc9fa9d0dde748f9d021ac331920861e6c0ccab1fabf0e4d5167873a0b4b.tgz",
+    "sha512": "eb4d373db53ebc25c8d1401b0469a78c6e22cc1d163bba8d0a08eb2bb24773fb9160fc9fa9d0dde748f9d021ac331920861e6c0ccab1fabf0e4d5167873a0b4b"
   },
   {
     "type": "file",
@@ -2430,10 +2430,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/workspace/-/workspace-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/8f",
-    "dest-filename": "8f3f2e278e6859d942cbe8a3f44cabc519fcd617964f77c04984fc0a178fb5e36ba4bad0584478e9bdb7903261deebcb138f75cc256206f80c25db17084b5bc7.tgz",
-    "sha512": "8f3f2e278e6859d942cbe8a3f44cabc519fcd617964f77c04984fc0a178fb5e36ba4bad0584478e9bdb7903261deebcb138f75cc256206f80c25db17084b5bc7"
+    "url": "https://registry.npmjs.org/@gjsify/workspace/-/workspace-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/e7",
+    "dest-filename": "e7c6692f9ef0d7f4de409d6fec456787498ae4f3f305e605ef0abf455bc891f8f3d07383a9b210f795fea93f8552cb8d24b0f2892fb32a0b429c78b5f6a53ec6.tgz",
+    "sha512": "e7c6692f9ef0d7f4de409d6fec456787498ae4f3f305e605ef0abf455bc891f8f3d07383a9b210f795fea93f8552cb8d24b0f2892fb32a0b429c78b5f6a53ec6"
   },
   {
     "type": "file",
@@ -2444,10 +2444,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/xmlhttprequest/-/xmlhttprequest-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/44",
-    "dest-filename": "449c6405aec7a24ad621b5633e31e06ff201594e3d9f4f30f50f223a593ab9650e390ab13e53c880457480d79ad11328a886c4a6c813ad70e110682d16595014.tgz",
-    "sha512": "449c6405aec7a24ad621b5633e31e06ff201594e3d9f4f30f50f223a593ab9650e390ab13e53c880457480d79ad11328a886c4a6c813ad70e110682d16595014"
+    "url": "https://registry.npmjs.org/@gjsify/xmlhttprequest/-/xmlhttprequest-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/52",
+    "dest-filename": "52aa4a585de4dbe1013fa164f2df8a29ddb97eeb4e58df38643bca09237eebb978db650ae58b7368ab601376fcde08eace9896c168bcd8550b35fd911d478ffa.tgz",
+    "sha512": "52aa4a585de4dbe1013fa164f2df8a29ddb97eeb4e58df38643bca09237eebb978db650ae58b7368ab601376fcde08eace9896c168bcd8550b35fd911d478ffa"
   },
   {
     "type": "file",
@@ -2458,10 +2458,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@gjsify/zlib/-/zlib-0.16.1.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/e8",
-    "dest-filename": "e82af9d74b1a37c6c3228598994128f5cd3804d56d618b3361944690d2bf395ab1892dd9f06602ef27066d0fe6dbc94ebc1da0a570e831e8cf01e4b8c4323f78.tgz",
-    "sha512": "e82af9d74b1a37c6c3228598994128f5cd3804d56d618b3361944690d2bf395ab1892dd9f06602ef27066d0fe6dbc94ebc1da0a570e831e8cf01e4b8c4323f78"
+    "url": "https://registry.npmjs.org/@gjsify/zlib/-/zlib-0.16.3.tgz",
+    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/db",
+    "dest-filename": "db06c19bc10882cb3a83cdb1e47c1891642521b5d72b138f2e6cd42575f681bb40db4b01298adc5159ccc089f9a325bf2eb08849014b89e57453d54d52e17dc3.tgz",
+    "sha512": "db06c19bc10882cb3a83cdb1e47c1891642521b5d72b138f2e6cd42575f681bb40db4b01298adc5159ccc089f9a325bf2eb08849014b89e57453d54d52e17dc3"
   },
   {
     "type": "file",
@@ -2857,13 +2857,6 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/01",
-    "dest-filename": "0163e805127db6c9d5868af8b233bbae49e2fbba7ed88004163e9cc74e9480fd748e4407a9acbfdfab9157f6c5920ae1d7c0fdbdbe1cafc4343ed86c920cf2f9.tgz",
-    "sha512": "0163e805127db6c9d5868af8b233bbae49e2fbba7ed88004163e9cc74e9480fd748e4407a9acbfdfab9157f6c5920ae1d7c0fdbdbe1cafc4343ed86c920cf2f9"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/64",
     "dest-filename": "64bbff25d51f92f3b2f5e0a79c16867e23be5e299b8de6c078ef8c450a83fc1f85475b6744dd2da4a4891d16c4f2c15f4ba6aab1767aed34237f07ecc542d56e.tgz",
@@ -3085,13 +3078,6 @@
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/2b",
     "dest-filename": "2b391d09de94c6a9dfea5dc73b0d717dab40954511034835e1cbc1605c89e5268d3906ce52f06bf4f280adc3dcacd21e46c05d81c533386ae12af795a6f38818.tgz",
     "sha512": "2b391d09de94c6a9dfea5dc73b0d717dab40954511034835e1cbc1605c89e5268d3906ce52f06bf4f280adc3dcacd21e46c05d81c533386ae12af795a6f38818"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/59",
-    "dest-filename": "593f866f6e22f219afa3ce4022fda8118a2e11791194a0254fd59a09add37cb80d08df8686b24e199b8894ca2e021dfc41ee103b1dba794395b2aef4a97af2c0.tgz",
-    "sha512": "593f866f6e22f219afa3ce4022fda8118a2e11791194a0254fd59a09add37cb80d08df8686b24e199b8894ca2e021dfc41ee103b1dba794395b2aef4a97af2c0"
   },
   {
     "type": "file",
@@ -3487,13 +3473,6 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.2.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/d9",
-    "dest-filename": "d9c67eef1452f8305cb890492a77f3b1b95eba626106a4a5255a6ecc70b49d3a9f777410ed5c76ff1e5847f0fb7016a6292796a65c28f36167f65a9850310c7c.tgz",
-    "sha512": "d9c67eef1452f8305cb890492a77f3b1b95eba626106a4a5255a6ecc70b49d3a9f777410ed5c76ff1e5847f0fb7016a6292796a65c28f36167f65a9850310c7c"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/11",
     "dest-filename": "1192e97fff32ec65e492b6bdd0c2f8ee4ce293f18c3f710c704f5b3f21e645fc4b0bacfdf9a5b903ca680aca318eb4f919f11c34002f5b05078ef3f5a544247f.tgz",
@@ -3505,13 +3484,6 @@
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/3d",
     "dest-filename": "3dc0213feca78d444dcb2f122869790d03fde1a1ae07fec9ad725bfedecffa16a75ef415316cd4bd1461040720fe535169d061a143ea4a83f8c70e6d47f28110.tgz",
     "sha512": "3dc0213feca78d444dcb2f122869790d03fde1a1ae07fec9ad725bfedecffa16a75ef415316cd4bd1461040720fe535169d061a143ea4a83f8c70e6d47f28110"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.2.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/46",
-    "dest-filename": "4643cc267ca0c6c80e61d91faa0a70634fc5ce6f1dd1541ee87194dbf074d176bd7aa74b6eb208f8338a02875b2409f764bd4027118791944f61ace0198e8b8f.tgz",
-    "sha512": "4643cc267ca0c6c80e61d91faa0a70634fc5ce6f1dd1541ee87194dbf074d176bd7aa74b6eb208f8338a02875b2409f764bd4027118791944f61ace0198e8b8f"
   },
   {
     "type": "file",
@@ -3529,13 +3501,6 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.2.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/52",
-    "dest-filename": "52273387abc5870c9f77b58d7bb43b9820382b10222ddcfb8cf13f5868b37d1a4889ea3216e35532633c1ea67d1f0b9d4e463afc078c43094d27d3498a382e5b.tgz",
-    "sha512": "52273387abc5870c9f77b58d7bb43b9820382b10222ddcfb8cf13f5868b37d1a4889ea3216e35532633c1ea67d1f0b9d4e463afc078c43094d27d3498a382e5b"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/17",
     "dest-filename": "17b8470b7830635d7ebc1c8a3d15aac066de5d65602a62fea531828a768485d8a1cc1576690d1fbd939c87d71761438ab8a2aae36f477985cea902dcef014212.tgz",
@@ -3547,13 +3512,6 @@
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/c8",
     "dest-filename": "c81d48940b123479dc57a4824cbdbbfcc54647986dbd0b281b122fe4a3065c02e9f8b975c18b27fb1f7c33d316eea6be35d49bbebad8ec0348e302c9d27d5eea.tgz",
     "sha512": "c81d48940b123479dc57a4824cbdbbfcc54647986dbd0b281b122fe4a3065c02e9f8b975c18b27fb1f7c33d316eea6be35d49bbebad8ec0348e302c9d27d5eea"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.2.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/f9",
-    "dest-filename": "f93a5db534601e22458c25456f0df5d52b8b93729fcad3ce4109fe565004bfe801c583ed2fb13a252f5efed93ef02c3184866f7a624aa38ad32a07d636c2a490.tgz",
-    "sha512": "f93a5db534601e22458c25456f0df5d52b8b93729fcad3ce4109fe565004bfe801c583ed2fb13a252f5efed93ef02c3184866f7a624aa38ad32a07d636c2a490"
   },
   {
     "type": "file",
@@ -3571,13 +3529,6 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.2.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/e2",
-    "dest-filename": "e25bf5fed9268bbb9e2151e7cab79a39e5298993f6e811fdad1cba86861f47ddf5d00d81f675045510ef071ebdbf1eb836bdde4cf3d1932722a8926cfa3f499b.tgz",
-    "sha512": "e25bf5fed9268bbb9e2151e7cab79a39e5298993f6e811fdad1cba86861f47ddf5d00d81f675045510ef071ebdbf1eb836bdde4cf3d1932722a8926cfa3f499b"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/98",
     "dest-filename": "9828b438a80489e162adcaed5589900051accd1b4c9d9e9fa59017af16a75c0bbb96a65cb0ad44d5101a64d1b4b8a027c68c770757f813240d9e8c8c7cdd6f00.tgz",
@@ -3589,13 +3540,6 @@
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/8e",
     "dest-filename": "8ec3bb47c4e8f80765620526379b0748265b7e1b4c0643b4594c7c88e4509cf70c31d82beea3360d098cc2069bb371a1373b5d9a82a430a4051c3e834cc08843.tgz",
     "sha512": "8ec3bb47c4e8f80765620526379b0748265b7e1b4c0643b4594c7c88e4509cf70c31d82beea3360d098cc2069bb371a1373b5d9a82a430a4051c3e834cc08843"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.2.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/80",
-    "dest-filename": "80149454ed1e696830d493232b7801f013255f6324d78f2cda54e2553ddef6f8d5c5b97b5037cc59663c09f21a6aa897b8cf5f553331229533e82028fc1e9597.tgz",
-    "sha512": "80149454ed1e696830d493232b7801f013255f6324d78f2cda54e2553ddef6f8d5c5b97b5037cc59663c09f21a6aa897b8cf5f553331229533e82028fc1e9597"
   },
   {
     "type": "file",
@@ -3613,13 +3557,6 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.2.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/2e",
-    "dest-filename": "2e340ffe264b06ef28f0f8c87e4e31dc0b74fe64fa876f36a6fcfc6792c0ca119bbbf9037b3c8eede6badab179ba8aa6827218a9b37f32a2774a2dc0ca68bbc5.tgz",
-    "sha512": "2e340ffe264b06ef28f0f8c87e4e31dc0b74fe64fa876f36a6fcfc6792c0ca119bbbf9037b3c8eede6badab179ba8aa6827218a9b37f32a2774a2dc0ca68bbc5"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/95",
     "dest-filename": "9595729b43ee1c4d4a676da09854c2d7994092b83d893b3347ad7ba18441fe23d8d40e7acb0a09cd528e24129aa2de518a290239b9aeafaa68829b1ede045c9e.tgz",
@@ -3631,13 +3568,6 @@
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/e5",
     "dest-filename": "e5fd65682d12948474c836c509df1a71486f2486a0e8ddf30b93fba143cdeb05f468e99afae289d300431f96aaec8d4f548dadb53961270cf04480672e248612.tgz",
     "sha512": "e5fd65682d12948474c836c509df1a71486f2486a0e8ddf30b93fba143cdeb05f468e99afae289d300431f96aaec8d4f548dadb53961270cf04480672e248612"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.2.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/5f",
-    "dest-filename": "5ffedb54b59e944b1bc960d4497b7bcd5b139e22cb3c86369f5ac7e7caabefc97d8bb30d6dbc41583f20236bd17c159fe0d51724252e4277d90eca77d8baac7d.tgz",
-    "sha512": "5ffedb54b59e944b1bc960d4497b7bcd5b139e22cb3c86369f5ac7e7caabefc97d8bb30d6dbc41583f20236bd17c159fe0d51724252e4277d90eca77d8baac7d"
   },
   {
     "type": "file",
@@ -3655,13 +3585,6 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.2.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/81",
-    "dest-filename": "81be9d60a5bfd4a0e8ac65f2cb8f20944049b3fb315520b9a5c56ba31fe91465789afc1215e836b0ae4bdad46456c56587b92e7aa3a083818472e8a925c1ae2a.tgz",
-    "sha512": "81be9d60a5bfd4a0e8ac65f2cb8f20944049b3fb315520b9a5c56ba31fe91465789afc1215e836b0ae4bdad46456c56587b92e7aa3a083818472e8a925c1ae2a"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/d1",
     "dest-filename": "d162119cbd54c3806f4d944b42df8f560a3a64a4c969d942d9bb4ffbf10e5efd9ffc359b634ac4825fb2f37e26215c0fd45913956553ac61895dfd7696bbbb11.tgz",
@@ -3673,13 +3596,6 @@
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/07",
     "dest-filename": "07c9bab43e7efcde4578d4056ca94b03fdb256af727103f549e79dc8461829604d4776506e4bc851c3670cd334de53b5979176ae88a21491a0be82cbc995ed4a.tgz",
     "sha512": "07c9bab43e7efcde4578d4056ca94b03fdb256af727103f549e79dc8461829604d4776506e4bc851c3670cd334de53b5979176ae88a21491a0be82cbc995ed4a"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.2.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/25",
-    "dest-filename": "258e30f39a54de2022255321e67ba4e3f321f468ccb2ea5ef0cac8379debc310195bae062ab59e241b8de92c5083d413539b81d5cc72843cd6f23a919f510007.tgz",
-    "sha512": "258e30f39a54de2022255321e67ba4e3f321f468ccb2ea5ef0cac8379debc310195bae062ab59e241b8de92c5083d413539b81d5cc72843cd6f23a919f510007"
   },
   {
     "type": "file",
@@ -3697,13 +3613,6 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.2.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/c6",
-    "dest-filename": "c6fa40ee8e4a0982c1d11c2c726bb295bd7fcc71d2531e20e318a59b8a6b0b98cfefaa44525cc198c6e0a5b87b6d50db21de0d71f4fdea03798ba984e940da8b.tgz",
-    "sha512": "c6fa40ee8e4a0982c1d11c2c726bb295bd7fcc71d2531e20e318a59b8a6b0b98cfefaa44525cc198c6e0a5b87b6d50db21de0d71f4fdea03798ba984e940da8b"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/ad",
     "dest-filename": "ad3eb241cc54b97b380a76e87eac0745157489e9b7e3dacb318a538e481018b8eb63869da3f783cf03d93d30a04ce945e8d929f0d12fef4c8b3139faaa45b1b1.tgz",
@@ -3715,13 +3624,6 @@
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/39",
     "dest-filename": "3975d2dd1289817dae2f033e818cae1f9a26707f1f2f52c9b3dea964682d7ad5426a138de7bf9de12247cd381988e8f18069129e95e93ac5ae3c31802808a012.tgz",
     "sha512": "3975d2dd1289817dae2f033e818cae1f9a26707f1f2f52c9b3dea964682d7ad5426a138de7bf9de12247cd381988e8f18069129e95e93ac5ae3c31802808a012"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.2.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/a7",
-    "dest-filename": "a7fb6ce8a04b8ee938f41a76d571fbee9a101add3688dcfb0a18077a9eedb9d3ce68b8a747f0defd11ddc45f30f188f8aff6c5fdba97c07e8f66b076b00f8dbf.tgz",
-    "sha512": "a7fb6ce8a04b8ee938f41a76d571fbee9a101add3688dcfb0a18077a9eedb9d3ce68b8a747f0defd11ddc45f30f188f8aff6c5fdba97c07e8f66b076b00f8dbf"
   },
   {
     "type": "file",
@@ -3739,13 +3641,6 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.2.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/54",
-    "dest-filename": "54cbbfc26ad9f612736254616f0ee32b93ce0e5ba0c8a67998e757efcfa54bc3afb85916350773d6914bac8da9dcfd298d73a6519ec1e3ca39567307f50386b6.tgz",
-    "sha512": "54cbbfc26ad9f612736254616f0ee32b93ce0e5ba0c8a67998e757efcfa54bc3afb85916350773d6914bac8da9dcfd298d73a6519ec1e3ca39567307f50386b6"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/e4",
     "dest-filename": "e4af37adbdfaa09898ec10b213dccb66d19c3d5e20e70beafb1c1d3b45cf2300d5648f1cc81fc052390d5c66fddbfae799ecc492330ea6063ad6bb708d0b45c2.tgz",
@@ -3760,13 +3655,6 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.2.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/c6",
-    "dest-filename": "c6d509aacf2a124b92be24b49f5b6ca2168fbb3ddad523e1672c0e8e2e0ea3eb20ac9b3c75a103319d10b6a2f4392eddc7c3e856983627f659c9c3d8e48dbe66.tgz",
-    "sha512": "c6d509aacf2a124b92be24b49f5b6ca2168fbb3ddad523e1672c0e8e2e0ea3eb20ac9b3c75a103319d10b6a2f4392eddc7c3e856983627f659c9c3d8e48dbe66"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/3e",
     "dest-filename": "3e7581b70dd357928e83af474100d1d269d0bb20a6486476a400780c2d6b3c5f34f1f80a79350c8f610e1322804e9822bb1b91e403d09a20ceecf0e01234c548.tgz",
@@ -3778,13 +3666,6 @@
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/79",
     "dest-filename": "79707b087b9a41daa625c73792808db4d3e64ff6e3da073df7d9141600711bc01cd0d7605dce2b9021e1aab82b84ddf375dbefbeb8338f57bdd12b927e6c885c.tgz",
     "sha512": "79707b087b9a41daa625c73792808db4d3e64ff6e3da073df7d9141600711bc01cd0d7605dce2b9021e1aab82b84ddf375dbefbeb8338f57bdd12b927e6c885c"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.2.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/f3",
-    "dest-filename": "f396222d0aa350a8123bf6639dff5ed17227e589ab8757cb0d605e02466aa6e051ff747c4e97e81d7bb26e5ab242b7ed4928163bdaa970737c9a4c8ab0badaa0.tgz",
-    "sha512": "f396222d0aa350a8123bf6639dff5ed17227e589ab8757cb0d605e02466aa6e051ff747c4e97e81d7bb26e5ab242b7ed4928163bdaa970737c9a4c8ab0badaa0"
   },
   {
     "type": "file",
@@ -4058,13 +3939,6 @@
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/63",
     "dest-filename": "63c70af5a820351b2a25568a525118b38b3b0af4356f5b5ad8354fc808a66f4236aa1ce3364f80fa6c6f965fe494bd1195fb8851e8bc045ed85a2b9ae2442ac3.tgz",
     "sha512": "63c70af5a820351b2a25568a525118b38b3b0af4356f5b5ad8354fc808a66f4236aa1ce3364f80fa6c6f965fe494bd1195fb8851e8bc045ed85a2b9ae2442ac3"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/46",
-    "dest-filename": "46806f2765f4c2e2a5585223af07df1b0d48a991ca42acc872129a69d6597e7369b00629da6334877e89b4f0a33430071a061ecffd79b8c0697c6c1c86188c82.tgz",
-    "sha512": "46806f2765f4c2e2a5585223af07df1b0d48a991ca42acc872129a69d6597e7369b00629da6334877e89b4f0a33430071a061ecffd79b8c0697c6c1c86188c82"
   },
   {
     "type": "file",
@@ -8132,13 +8006,6 @@
     "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/8b",
     "dest-filename": "8b4d25009da4b35058afbae3363282ec172a012ee755f893dd05f5488e5a63e0051db94299a51ff4e13d75b7730ef5ba749c5b8b6642662cbdbf709cc0e897de.tgz",
     "sha512": "8b4d25009da4b35058afbae3363282ec172a012ee755f893dd05f5488e5a63e0051db94299a51ff4e13d75b7730ef5ba749c5b8b6642662cbdbf709cc0e897de"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.2.tgz",
-    "dest": "flatpak-gjsify-cache/gjsify/tarballs/v1/sha512/c7",
-    "dest-filename": "c740ab410a825d619e23c753bc57cdfc39efdf230a4fd86fe6316394eade280c7dc2a2eaf70cfb56f2cb1f26805c2f74fc2a60813bbd4a2b126ec2494cf4a335.tgz",
-    "sha512": "c740ab410a825d619e23c753bc57cdfc39efdf230a4fd86fe6316394eade280c7dc2a2eaf70cfb56f2cb1f26805c2f74fc2a60813bbd4a2b126ec2494cf4a335"
   },
   {
     "type": "file",

--- a/packages/app-web/app.html
+++ b/packages/app-web/app.html
@@ -10,6 +10,6 @@
     <!-- Dev entry for the new adwaita-web shell (Vite gjsifyBrowser preset).
          Separate from the classic Jekyll site so its published output is
          untouched. Production is built with `gjsify build --app browser`. -->
-    <script type="module" src="/src/app/main.ts"></script>
+    <script type="module" src="./src/app/main.ts"></script>
   </body>
 </html>

--- a/packages/app-web/package.json
+++ b/packages/app-web/package.json
@@ -10,7 +10,7 @@
     "setup": "gem install bundler jekyll && bundle install",
     "build:vite": "vite build",
     "build": "gjsify run build:vite",
-    "build:app": "gjsify build src/app/main.ts --app browser --outfile dist-app/app.js --alias @gjsify/adwaita-fonts=@gjsify/empty && node scripts/write-app-html.mjs",
+    "build:app": "gjsify build app.html --app browser --outfile dist-app/app.js --alias @gjsify/adwaita-fonts=@gjsify/empty",
     "dev:app": "vite --config vite.app.config.ts",
     "preview:app": "vite preview --config vite.app.config.ts",
     "check": "gjsify tsc --noEmit",
@@ -26,14 +26,14 @@
     }
   },
   "devDependencies": {
-    "@gjsify/cli": "^0.16.1",
-    "@gjsify/vite-plugin-gjsify": "^0.16.1",
+    "@gjsify/cli": "^0.16.3",
+    "@gjsify/vite-plugin-gjsify": "^0.16.3",
     "lightningcss": "^1.32.0",
     "typescript": "^6.0.3",
     "vite": "^8.0.16"
   },
   "dependencies": {
-    "@gjsify/adwaita-web": "^0.16.1",
+    "@gjsify/adwaita-web": "^0.16.3",
     "@learn6502/common-ui": "^0.7.0",
     "@learn6502/core": "^0.7.0",
     "@learn6502/learn": "^0.7.0"

--- a/packages/app-web/src/app/styles.css
+++ b/packages/app-web/src/app/styles.css
@@ -1,0 +1,139 @@
+/*
+ * Layout stylesheet for the app-web Adwaita SPA shell.
+ *
+ * Only the app-level LAYOUT lives here (full-viewport frame, the adaptive
+ * single/three-column arrangement, run-control spacing). Every widget's own
+ * look comes from the `@gjsify/adwaita-web` skin, which self-injects on import.
+ *
+ * Authored as a real .css file and consumed as a string via css-as-string
+ * (`import shellCss from './styles.css'`), the same pattern the native
+ * app-gnome uses (`import mainCss from './main.css'` → Gtk.CssProvider) — the
+ * browser applies it through a <style> element in ./styles.ts.
+ */
+
+html,
+body {
+  margin: 0;
+  height: 100%;
+}
+
+body {
+  background: var(--window-bg-color, #fafafb);
+  color: var(--window-fg-color, rgb(0 0 6 / 80%));
+  font-family: "Adwaita Sans", "Cantarell", sans-serif;
+}
+
+#application-window {
+  display: block;
+  width: 100%;
+  height: 100vh;
+  height: 100dvh;
+}
+
+#application-window > adw-toolbar-view {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+#application-window .adw-toolbar-view-content {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+/* The toast overlay + its content wrapper + layout host fill the content area. */
+#application-window adw-toast-overlay,
+#application-window .adw-toast-overlay-content,
+#layout-host {
+  display: block;
+  height: 100%;
+  min-height: 0;
+}
+
+#layout-host {
+  position: relative;
+}
+
+#mobile-layout,
+#desktop-layout {
+  height: 100%;
+  min-height: 0;
+}
+
+/* --- Mobile: single ViewStack, one page visible at a time --- */
+#mobile-layout {
+  display: flex;
+  flex-direction: column;
+  overflow: auto;
+}
+
+#mobile-layout adw-view-stack {
+  display: block;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+/* --- Desktop: Learn sidebar | Editor | (GameConsole over Debugger) --- */
+#desktop-layout {
+  display: flex;
+}
+
+#desktop-layout adw-overlay-split-view {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.shell-center-right {
+  display: flex;
+  flex-direction: row;
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 100%;
+}
+
+.shell-center-column {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: auto;
+  padding: 12px;
+}
+
+.shell-right-column {
+  flex: 0 0 340px;
+  width: 340px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  border-inline-start: 1px solid var(--border-color, rgb(0 0 0 / 12%));
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.shell-sidebar-column {
+  height: 100%;
+  overflow: auto;
+  padding: 12px;
+  box-sizing: border-box;
+}
+
+/* Each view fills its host slot. */
+.shell-view-slot {
+  display: block;
+  height: 100%;
+  min-height: 0;
+}
+
+/* Header run controls sit in a tight linked-ish group. */
+.shell-run-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-inline-start: 6px;
+}
+
+/* Placeholder status pages breathe inside their column. */
+.shell-view-slot adw-status-page {
+  display: flex;
+  height: 100%;
+}

--- a/packages/app-web/src/app/styles.ts
+++ b/packages/app-web/src/app/styles.ts
@@ -1,144 +1,15 @@
 /**
- * Self-injected layout stylesheet for the app-web Adwaita SPA shell.
+ * Applies the shell layout stylesheet (`./styles.css`).
  *
- * Only the app-level LAYOUT lives here (full-viewport frame, the adaptive
- * single/three-column arrangement, run-control spacing). Every widget's own
- * look comes from the `@gjsify/adwaita-web` skin, which self-injects on import.
- *
- * Injected via a `<style>` element (the same pattern adwaita-web and the
- * debugger widgets use) so it works identically under Vite dev and a
- * `gjsify build --app browser` bundle — no `.css` import to route through a
- * bundler's CSS pipeline.
+ * The CSS is authored in a real `.css` file and imported as a string via
+ * gjsify's css-as-string (identical under Vite dev with
+ * `gjsifyBrowser({ cssAsString: true })` and a `gjsify build --app browser`
+ * bundle) — the same author-once pattern the native app-gnome uses
+ * (`import mainCss from './main.css'` → `Gtk.CssProvider.load_from_string`).
+ * The browser applies the string through a one-shot `<style>` element.
  */
 
-const SHELL_CSS = /* css */ `
-html,
-body {
-  margin: 0;
-  height: 100%;
-}
-
-body {
-  background: var(--window-bg-color, #fafafb);
-  color: var(--window-fg-color, rgb(0 0 6 / 80%));
-  font-family: "Adwaita Sans", "Cantarell", sans-serif;
-}
-
-#application-window {
-  display: block;
-  width: 100%;
-  height: 100vh;
-  height: 100dvh;
-}
-
-#application-window > adw-toolbar-view {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-}
-
-#application-window .adw-toolbar-view-content {
-  flex: 1 1 auto;
-  min-height: 0;
-}
-
-/* The toast overlay + its content wrapper + layout host fill the content area. */
-#application-window adw-toast-overlay,
-#application-window .adw-toast-overlay-content,
-#layout-host {
-  display: block;
-  height: 100%;
-  min-height: 0;
-}
-
-#layout-host {
-  position: relative;
-}
-
-#mobile-layout,
-#desktop-layout {
-  height: 100%;
-  min-height: 0;
-}
-
-/* --- Mobile: single ViewStack, one page visible at a time --- */
-#mobile-layout {
-  display: flex;
-  flex-direction: column;
-  overflow: auto;
-}
-
-#mobile-layout adw-view-stack {
-  display: block;
-  flex: 1 1 auto;
-  min-height: 0;
-}
-
-/* --- Desktop: Learn sidebar | Editor | (GameConsole over Debugger) --- */
-#desktop-layout {
-  display: flex;
-}
-
-#desktop-layout adw-overlay-split-view {
-  flex: 1 1 auto;
-  min-height: 0;
-}
-
-.shell-center-right {
-  display: flex;
-  flex-direction: row;
-  flex: 1 1 auto;
-  min-width: 0;
-  height: 100%;
-}
-
-.shell-center-column {
-  flex: 1 1 auto;
-  min-width: 0;
-  overflow: auto;
-  padding: 12px;
-}
-
-.shell-right-column {
-  flex: 0 0 340px;
-  width: 340px;
-  overflow-y: auto;
-  overflow-x: hidden;
-  border-inline-start: 1px solid var(--border-color, rgb(0 0 0 / 12%));
-  padding: 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.shell-sidebar-column {
-  height: 100%;
-  overflow: auto;
-  padding: 12px;
-  box-sizing: border-box;
-}
-
-/* Each view fills its host slot. */
-.shell-view-slot {
-  display: block;
-  height: 100%;
-  min-height: 0;
-}
-
-/* Header run controls sit in a tight linked-ish group. */
-.shell-run-controls {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  margin-inline-start: 6px;
-}
-
-/* Placeholder status pages breathe inside their column. */
-.shell-view-slot adw-status-page {
-  display: flex;
-  height: 100%;
-}
-`;
+import shellCss from "./styles.css";
 
 let injected = false;
 
@@ -149,6 +20,6 @@ export function injectShellStyles(): void {
   if (document.getElementById("learn6502-shell-style")) return;
   const style = document.createElement("style");
   style.id = "learn6502-shell-style";
-  style.textContent = SHELL_CSS;
+  style.textContent = shellCss;
   document.head.appendChild(style);
 }

--- a/packages/app-web/src/types/css.d.ts
+++ b/packages/app-web/src/types/css.d.ts
@@ -1,0 +1,9 @@
+// `*.css` imports resolve to a JS string default export — via gjsify's
+// css-as-string (`gjsify build --app browser`) and, in Vite dev, the
+// `gjsifyBrowser({ cssAsString: true })` preset. Same author-once pattern the
+// native app-gnome uses for its `.css` files. Ambient (non-module) file so
+// `declare module "*.css"` is global.
+declare module "*.css" {
+  const content: string;
+  export default content;
+}

--- a/packages/app-web/src/widgets/debugger/styles.css
+++ b/packages/app-web/src/widgets/debugger/styles.css
@@ -1,0 +1,66 @@
+/*
+ * Stylesheet for the common-ui debugger widgets (code blocks, copy button,
+ * register/flag grid). Everything else comes from the @gjsify/adwaita-web skin.
+ * Authored as a real .css file, imported as a string via css-as-string and
+ * self-injected on import (see ./styles.ts).
+ */
+
+learn-debugger {
+  display: block;
+}
+
+learn-debugger .learn-section-heading {
+  display: block;
+  font-weight: bold;
+  margin: 18px 0 8px;
+}
+
+learn-debugger .learn-code-card {
+  position: relative;
+  display: block;
+  padding: 10px 14px;
+}
+
+learn-debugger .learn-code-card pre {
+  margin: 0;
+  max-height: 240px;
+  overflow: auto;
+  font-family: ui-monospace, "Adwaita Mono", monospace;
+  font-size: 0.85em;
+  line-height: 1.45;
+  white-space: pre;
+}
+
+learn-debugger .learn-copy-button {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+}
+
+learn-debugger .learn-register-value {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  font-family: ui-monospace, "Adwaita Mono", monospace;
+}
+
+learn-debugger .learn-register-value .learn-register-dec {
+  opacity: 0.55;
+  font-size: 0.8em;
+}
+
+learn-debugger .learn-flags-grid {
+  display: grid;
+  grid-template-columns: repeat(8, 1.2em);
+  justify-items: center;
+  font-family: ui-monospace, "Adwaita Mono", monospace;
+}
+
+learn-debugger .learn-flags-grid .learn-flag-header {
+  opacity: 0.55;
+  font-size: 0.8em;
+}
+
+learn-debugger .learn-flag-off {
+  opacity: 0.4;
+}

--- a/packages/app-web/src/widgets/debugger/styles.ts
+++ b/packages/app-web/src/widgets/debugger/styles.ts
@@ -1,76 +1,15 @@
 /**
- * Shared stylesheet for the common-ui debugger widgets (ADR 0007 spike).
- * Self-injected on import — the same pattern `@gjsify/adwaita-web` uses for
- * its own skin, so a single side-effect import styles all debugger widgets.
- * Only spike-specific chrome lives here (code blocks, copy button, flag grid);
- * everything else comes from the adwaita-web skin.
+ * Self-injects the debugger widgets' stylesheet (`./styles.css`) on import —
+ * a single side-effect import styles all debugger widgets, the same pattern
+ * `@gjsify/adwaita-web` uses for its own skin. The CSS is authored in a real
+ * `.css` file and imported as a string via gjsify's css-as-string.
  */
 
-const DEBUGGER_CSS = /* css */ `
-learn-debugger {
-  display: block;
-}
-
-learn-debugger .learn-section-heading {
-  display: block;
-  font-weight: bold;
-  margin: 18px 0 8px;
-}
-
-learn-debugger .learn-code-card {
-  position: relative;
-  display: block;
-  padding: 10px 14px;
-}
-
-learn-debugger .learn-code-card pre {
-  margin: 0;
-  max-height: 240px;
-  overflow: auto;
-  font-family: ui-monospace, "Adwaita Mono", monospace;
-  font-size: 0.85em;
-  line-height: 1.45;
-  white-space: pre;
-}
-
-learn-debugger .learn-copy-button {
-  position: absolute;
-  top: 6px;
-  right: 6px;
-}
-
-learn-debugger .learn-register-value {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  font-family: ui-monospace, "Adwaita Mono", monospace;
-}
-
-learn-debugger .learn-register-value .learn-register-dec {
-  opacity: 0.55;
-  font-size: 0.8em;
-}
-
-learn-debugger .learn-flags-grid {
-  display: grid;
-  grid-template-columns: repeat(8, 1.2em);
-  justify-items: center;
-  font-family: ui-monospace, "Adwaita Mono", monospace;
-}
-
-learn-debugger .learn-flags-grid .learn-flag-header {
-  opacity: 0.55;
-  font-size: 0.8em;
-}
-
-learn-debugger .learn-flag-off {
-  opacity: 0.4;
-}
-`;
+import debuggerCss from "./styles.css";
 
 if (typeof document !== "undefined" && !document.getElementById("learn-debugger-style")) {
   const style = document.createElement("style");
   style.id = "learn-debugger-style";
-  style.textContent = DEBUGGER_CSS;
+  style.textContent = debuggerCss;
   document.head.appendChild(style);
 }

--- a/packages/app-web/src/widgets/learn/styles.css
+++ b/packages/app-web/src/widgets/learn/styles.css
@@ -1,0 +1,100 @@
+/*
+ * Stylesheet for the Learn view's rendered tutorial content.
+ *
+ * `@learn6502/learn`'s HTML render target (`HtmlComponents`) emits a small,
+ * deliberately generic vocabulary instead of anything adwaita-web-specific
+ * (see `packages/learn/tsx/components/html/`): a `learn-view` root, `adw-box`
+ * flex containers, `title-1`..`title-4`/`body` Adwaita typography classes,
+ * and `adw-list` for `<ol>`/`<ul>`. None of these exist in the adwaita-web
+ * skin (which only styles its own custom elements), so the consuming app
+ * owns their look — this is that stylesheet. Typography sizes/weights match
+ * libadwaita's `_labels.scss` (`.title-1`..`.title-4`, `.body`) so the
+ * rendered tutorial reads like native GNOME Learn6502.
+ *
+ * Authored as a real .css file, imported as a string via css-as-string and
+ * self-injected on import (see ./styles.ts).
+ */
+
+learn-view {
+  display: block;
+  height: 100%;
+  overflow-y: auto;
+  box-sizing: border-box;
+}
+
+/* The rendered fragment's root carries BOTH "adw-box adw-box--vertical" (its
+   HtmlBox wrapper) and "learn-view" (HtmlRoot's own marker class) — the
+   .adw-box rules below already give it its vertical flex layout. */
+
+learn-view .adw-box {
+  display: flex;
+}
+
+learn-view .adw-box--vertical {
+  flex-direction: column;
+  gap: 12px;
+}
+
+learn-view .adw-box--horizontal {
+  flex-direction: row;
+  gap: 12px;
+  align-items: center;
+}
+
+/* Adwaita typography style classes (libadwaita _labels.scss parity). */
+learn-view .title-1 {
+  font-weight: 800;
+  font-size: 181%;
+  margin: 0.6em 0 0.3em;
+}
+
+learn-view .title-2 {
+  font-weight: 800;
+  font-size: 136%;
+  margin: 0.6em 0 0.3em;
+}
+
+learn-view .title-3 {
+  font-weight: 700;
+  font-size: 136%;
+  margin: 0.6em 0 0.3em;
+}
+
+learn-view .title-4 {
+  font-weight: 700;
+  font-size: 118%;
+  margin: 0.6em 0 0.3em;
+}
+
+learn-view .body {
+  font-weight: 400;
+  line-height: 140%;
+  margin: 0 0 0.6em;
+}
+
+learn-view .adw-list {
+  margin: 0 0 0.6em;
+  padding-inline-start: 1.4em;
+  line-height: 140%;
+}
+
+learn-view .adw-list li {
+  margin-bottom: 0.3em;
+}
+
+learn-view code {
+  font-family: ui-monospace, "Adwaita Mono", monospace;
+  font-size: 0.9em;
+  background: var(--card-bg-color, rgb(0 0 0 / 6%));
+  border-radius: 4px;
+  padding: 0.1em 0.35em;
+}
+
+/* Fenced code blocks upgrade to <adw-source-view> (registered by
+   @gjsify/adwaita-web/source-view); give the block some breathing room. */
+learn-view adw-source-view {
+  display: block;
+  margin: 0.6em 0 1em;
+  border-radius: 12px;
+  overflow: hidden;
+}

--- a/packages/app-web/src/widgets/learn/styles.ts
+++ b/packages/app-web/src/widgets/learn/styles.ts
@@ -1,108 +1,15 @@
 /**
- * Shared stylesheet for the Learn view's rendered tutorial content.
- * Self-injected on import — the same pattern `@gjsify/adwaita-web` and the
- * debugger widgets (`widgets/debugger/styles.ts`) use.
- *
- * `@learn6502/learn`'s HTML render target (`HtmlComponents`) emits a small,
- * deliberately generic vocabulary instead of anything adwaita-web-specific
- * (see `packages/learn/tsx/components/html/`): a `learn-view` root, `adw-box`
- * flex containers, `title-1`..`title-4`/`body` Adwaita typography classes,
- * and `adw-list` for `<ol>`/`<ul>`. None of these exist in the adwaita-web
- * skin (which only styles its own custom elements), so the consuming app
- * owns their look — this is that stylesheet. Typography sizes/weights match
- * libadwaita's `_labels.scss` (`.title-1`..`.title-4`, `.body`) so the
- * rendered tutorial reads like native GNOME Learn6502.
+ * Self-injects the Learn view's stylesheet (`./styles.css`) on import — the
+ * same pattern `@gjsify/adwaita-web` and the debugger widgets
+ * (`widgets/debugger/styles.ts`) use. The CSS is authored in a real `.css`
+ * file and imported as a string via gjsify's css-as-string.
  */
 
-const LEARN_CSS = /* css */ `
-learn-view {
-  display: block;
-  height: 100%;
-  overflow-y: auto;
-  box-sizing: border-box;
-}
-
-/* The rendered fragment's root carries BOTH "adw-box adw-box--vertical" (its
-   HtmlBox wrapper) and "learn-view" (HtmlRoot's own marker class) — the
-   .adw-box rules below already give it its vertical flex layout. */
-
-learn-view .adw-box {
-  display: flex;
-}
-
-learn-view .adw-box--vertical {
-  flex-direction: column;
-  gap: 12px;
-}
-
-learn-view .adw-box--horizontal {
-  flex-direction: row;
-  gap: 12px;
-  align-items: center;
-}
-
-/* Adwaita typography style classes (libadwaita _labels.scss parity). */
-learn-view .title-1 {
-  font-weight: 800;
-  font-size: 181%;
-  margin: 0.6em 0 0.3em;
-}
-
-learn-view .title-2 {
-  font-weight: 800;
-  font-size: 136%;
-  margin: 0.6em 0 0.3em;
-}
-
-learn-view .title-3 {
-  font-weight: 700;
-  font-size: 136%;
-  margin: 0.6em 0 0.3em;
-}
-
-learn-view .title-4 {
-  font-weight: 700;
-  font-size: 118%;
-  margin: 0.6em 0 0.3em;
-}
-
-learn-view .body {
-  font-weight: 400;
-  line-height: 140%;
-  margin: 0 0 0.6em;
-}
-
-learn-view .adw-list {
-  margin: 0 0 0.6em;
-  padding-inline-start: 1.4em;
-  line-height: 140%;
-}
-
-learn-view .adw-list li {
-  margin-bottom: 0.3em;
-}
-
-learn-view code {
-  font-family: ui-monospace, "Adwaita Mono", monospace;
-  font-size: 0.9em;
-  background: var(--card-bg-color, rgb(0 0 0 / 6%));
-  border-radius: 4px;
-  padding: 0.1em 0.35em;
-}
-
-/* Fenced code blocks upgrade to <adw-source-view> (registered by
-   @gjsify/adwaita-web/source-view); give the block some breathing room. */
-learn-view adw-source-view {
-  display: block;
-  margin: 0.6em 0 1em;
-  border-radius: 12px;
-  overflow: hidden;
-}
-`;
+import learnCss from "./styles.css";
 
 if (typeof document !== "undefined" && !document.getElementById("learn-view-style")) {
   const style = document.createElement("style");
   style.id = "learn-view-style";
-  style.textContent = LEARN_CSS;
+  style.textContent = learnCss;
   document.head.appendChild(style);
 }

--- a/packages/app-web/tsconfig.json
+++ b/packages/app-web/tsconfig.json
@@ -14,5 +14,11 @@
     "alwaysStrict": true,
     "diagnostics": true
   },
-  "files": ["src/main.ts", "src/app/main.ts", "src/types/adwaita-fonts.d.ts", "src/types/html-module.d.ts"]
+  "files": [
+    "src/main.ts",
+    "src/app/main.ts",
+    "src/types/adwaita-fonts.d.ts",
+    "src/types/html-module.d.ts",
+    "src/types/css.d.ts"
+  ]
 }

--- a/packages/app-web/vite.app.config.ts
+++ b/packages/app-web/vite.app.config.ts
@@ -14,7 +14,10 @@ import { gjsifyBrowser } from "@gjsify/vite-plugin-gjsify";
 // dev experience matches the shipped bundle (minus css-as-string, which a real
 // browser app wants routed through Vite's native CSS pipeline).
 export default defineConfig({
-  plugins: [...gjsifyBrowser()],
+  // `cssAsString: true` makes `import css from './x.css'` yield the CSS string
+  // in dev (matching `gjsify build --app browser`), so the shell + widget
+  // styles apply identically dev/prod via a <style> element.
+  plugins: [...gjsifyBrowser({ cssAsString: true })],
   server: { open: "/app.html" },
   build: {
     outDir: "dist-app",


### PR DESCRIPTION
Re-lands the app-web modernization onto **gjsify 0.16.3**'s Vite-standard web-dev features, and extends it to the **Learn view**. (A prior attempt was lost to a botched `git add` — main still carried the old CSS-as-TS-string styles + the `write-app-html.mjs` step, so the original request — styles as real `.css`, `index.html` instead of a hand-written script — wasn't actually satisfied in the app.)

## What
- **Styles → real `.css`** for all three widget groups: `src/app/styles.css`, `src/widgets/debugger/styles.css`, and the **Learn view**'s `src/widgets/learn/styles.css`. Each `styles.ts` is now a thin `import css from "./styles.css"` + `<style>` injector — the same author-once pattern the native app-gnome uses (`import mainCss` → `Gtk.CssProvider`). Dev parity via `gjsifyBrowser({ cssAsString: true })`; a `*.css` module decl (`src/types/css.d.ts`) for tsc.
- **HTML entry**: `build:app` takes `app.html` as the entry (`gjsify build app.html --app browser`), which emits `dist-app/index.html` with the script `src` rewritten to the bundle — so `scripts/write-app-html.mjs` is **removed** from the pipeline. `app.html`'s script src is now the relative `./src/app/main.ts` (resolves under both Vite dev and the gjsify build).
- **Bump** `@gjsify/{cli,vite-plugin-gjsify,adwaita-web}` to `^0.16.3`; regenerate `gjsify-lock.json` + `gjsify-sources.json` (1313 tarball sources) so the offline Flatpak build has the 0.16.3 tarballs.

## Verification (all run against the local 0.16.3 CLI)
- `gjsify workspace @learn6502/app-web build:app` → **exit 0**, emits both `dist-app/app.js` (704 KB full bundle) **and** `dist-app/index.html`. The HTML-entry feature rewrote the script src to `src="./app.js"`.
- The shell + debugger + Learn CSS is inlined in `app.js` via css-as-string: `shell-center-column` (×2), `learn-debugger` (×11), `learn-view` (×15), plus the three `<style>`-injector ids.
- `gjsify tsc --noEmit`: **0 errors** (the `*.css` decl resolves the imports).
- `gjsify format --check` on `packages/app-web`: **clean** (27 files).

https://claude.ai/code/session_01M447HZHo6YgQem4K3TXq9r
