### PR TITLE
Web: app-web Editor view (CodeMirror source-view)

### DIFF
--- a/packages/app-web/src/app/main-window.ts
+++ b/packages/app-web/src/app/main-window.ts
@@ -24,9 +24,10 @@
  *
  * Phase 1 shipped the Debugger as the first REAL view (the ADR-0007 spike's
  * `AdwDebuggerView`, wired through the shared `GameConsoleEventBridge`).
- * Phase 2 adds Learn (`AdwLearnView`, rendering `@learn6502/learn`'s
- * generated tutorial HTML). Editor and GameConsole remain `adw-status-page`
- * placeholders that later phases replace.
+ * Phase 2 added Learn (`AdwLearnView`, rendering `@learn6502/learn`'s generated
+ * tutorial HTML). Phase 3 adds the Editor (`AdwEditorView`, the CodeMirror
+ * `<adw-source-view>` + quick-help sheet). GameConsole remains an
+ * `adw-status-page` placeholder that a later phase replaces.
  */
 
 import {
@@ -57,6 +58,7 @@ import {
 import { Assembler, Labels, Memory, Simulator, SimulatorState, formatMessage } from "@learn6502/core";
 
 import { AdwDebuggerView } from "../views/adw-debugger.js";
+import { AdwEditorView } from "../widgets/editor/index.js";
 import { AdwLearnView } from "../widgets/learn/index.js";
 import { injectShellStyles } from "./styles.js";
 
@@ -69,7 +71,7 @@ const NOTIFICATION_TITLES: Record<string, string> = {
   "program-completed": "Program completed",
 };
 
-/** A small demo program so Assemble → Debug works before the editor phase lands. */
+/** The starter program the Editor opens with — Assemble, then Run or Step. */
 const DEMO_PROGRAM = `; Fill the display page at $0200 with random colors.
 ; Assemble, then Run or Step to watch the debugger update.
   LDX #$00
@@ -100,8 +102,9 @@ export class MainWindow implements MainView {
   private readonly simulator = new Simulator(this.memory, this.labels);
   private readonly assembler = new Assembler(this.memory, this.labels);
 
-  // Real views; Editor and GameConsole remain placeholders (later phases).
+  // Real views; GameConsole remains a placeholder (later phase).
   private readonly debuggerView = new AdwDebuggerView();
+  private readonly editorView = new AdwEditorView();
   private readonly learnView = new AdwLearnView();
 
   // Persistent per-view slot wrappers, re-homed between the two layouts.
@@ -257,17 +260,13 @@ export class MainWindow implements MainView {
   }
 
   private buildViews(): void {
-    // Editor / GameConsole placeholders; Learn and Debugger are real views.
+    // GameConsole is still a placeholder; Learn, Editor and Debugger are real.
     this.learnView.classList.add("shell-view-slot");
     this.learnSlot.appendChild(this.learnView);
 
-    this.editorSlot.appendChild(
-      this.placeholder(
-        "document-edit",
-        "Editor",
-        "The CodeMirror source editor arrives in a later phase. A demo program is loaded — try Assemble, then Run or Step."
-      )
-    );
+    this.editorView.classList.add("shell-view-slot");
+    this.editorSlot.appendChild(this.editorView);
+
     this.gameConsoleSlot.appendChild(
       this.placeholder(
         "application-x-executable",
@@ -329,6 +328,12 @@ export class MainWindow implements MainView {
     ];
     menuButton.addEventListener("menu-item-activated", (event) => {
       const id = (event as CustomEvent<{ id: string }>).detail.id;
+      if (id === "help") {
+        // Reveal the Editor's 6502 quick-help sheet (the GNOME twin's help).
+        this.navigateToView(ViewType.EDITOR);
+        editorController.setHelpVisible(true);
+        return;
+      }
       this.showToast(`Menu: ${id} (coming soon)`);
     });
 
@@ -435,6 +440,10 @@ export class MainWindow implements MainView {
       this.showToast("Code copied to editor");
     });
 
+    // A user edit in the Editor marks the program dirty (the MainEventBridge
+    // seam the GNOME/Android main views use — the web shell wires it directly).
+    editorController.events.on("changed", () => mainStateController.setCodeChanged(true));
+
     // Main UI state → run-control enablement.
     mainStateController.events.on("state-changed", () => this.updateRunActions(this.simulator.state));
     mainStateController.events.on("state-changed:code-changed", (changed: boolean) => {
@@ -502,6 +511,7 @@ export class MainWindow implements MainView {
       // Preserve the tutorial's reading position across mobile tab switches
       // (the GNOME twin's saveScrollPosition/restoreScrollPosition seam).
       if (previous === ViewType.LEARN && slot.type !== ViewType.LEARN) this.learnView.saveScrollPosition();
+      if (previous === ViewType.EDITOR && slot.type !== ViewType.EDITOR) this.editorView.saveState();
       if (slot.type === ViewType.LEARN) this.learnView.restoreScrollPosition();
       if (slot.type === ViewType.DEBUGGER) this.updateDebugger();
     });

--- a/packages/app-web/src/widgets/editor/editor-view.ts
+++ b/packages/app-web/src/widgets/editor/editor-view.ts
@@ -1,0 +1,157 @@
+import { AdwBottomSheet, AdwBottomSheetContent, AdwBottomSheetSheet, AdwButton } from "@gjsify/adwaita-web";
+import { EventDispatcher } from "@learn6502/core";
+import type {
+  EditorChangedEvent,
+  EditorEventMap,
+  EditorHelpVisibilityChangedEvent,
+  EditorView,
+} from "@learn6502/common-ui";
+import { editorController } from "@learn6502/common-ui";
+
+import { QuickHelp } from "./quick-help.js";
+import { SourceView } from "./source-view.js";
+
+/**
+ * AdwEditorView — the `EditorView` from `@learn6502/common-ui` implemented over
+ * `@gjsify/adwaita-web`, the web twin of app-gnome's `Editor extends Adw.Bin`
+ * (`editor.blp`) and app-android's `Editor` NativeScript view.
+ *
+ * Structure mirrors `editor.blp`: an `Adw.BottomSheet` whose persistent content
+ * is the 6502 `SourceView` (CodeMirror) and whose slide-up sheet is the
+ * `QuickHelp` reference card, with a "Help" bar button to reveal it. As on GNOME
+ * and Android, ALL logic lives in the shared `editorController` — this class
+ * only builds widgets, wires them to the controller, and bridges the help-sheet
+ * open state to `editorController.helpVisible`.
+ *
+ * @emits changed - when the editor content is updated (forwarded from the controller)
+ */
+export class AdwEditorView extends HTMLElement implements EditorView {
+  readonly events: EventDispatcher<EditorEventMap> = new EventDispatcher<EditorEventMap>();
+
+  private readonly sourceView = new SourceView();
+  private readonly quickHelp = new QuickHelp();
+  private readonly bottomSheet = new AdwBottomSheet();
+  private readonly helpButton = new AdwButton();
+
+  private built = false;
+  private initialized = false;
+  // Guards the two-way help-sheet ⇄ controller sync from feedback loops.
+  private syncingHelp = false;
+
+  private readonly onControllerChanged = (event: EditorChangedEvent): void => {
+    this.events.dispatch("changed", event);
+  };
+
+  private readonly onHelpVisibilityChanged = (event: EditorHelpVisibilityChangedEvent): void => {
+    if (this.syncingHelp) return;
+    this.syncingHelp = true;
+    this.bottomSheet.open = event.visible;
+    this.syncingHelp = false;
+  };
+
+  connectedCallback(): void {
+    this.ensureBuilt();
+  }
+
+  // --- EditorView interface (delegates to editorController, like the twins) ---
+
+  get code(): string {
+    return editorController.code;
+  }
+
+  set code(value: string) {
+    this.setCode(value);
+  }
+
+  public setCode(value: string): void {
+    editorController.setCode(value);
+  }
+
+  get hasCode(): boolean {
+    return editorController.hasCode;
+  }
+
+  public addContent(content: string): void {
+    editorController.addContent(content);
+  }
+
+  public clear(): void {
+    editorController.clear();
+  }
+
+  public focus(): boolean {
+    this.ensureBuilt();
+    return this.sourceView.focus();
+  }
+
+  /** Persist the current buffer to the controller (before navigation/close). */
+  public saveState(): void {
+    editorController.saveState();
+  }
+
+  // --- DOM construction ---
+
+  private ensureBuilt(): void {
+    if (this.built) return;
+    this.built = true;
+
+    // Persistent content: the source editor filling the pane, with a "Help"
+    // bar pinned below it (the web stand-in for editor.blp's bottom-bar Label).
+    // AdwBottomSheet re-homes the CHILDREN of <adw-bottom-sheet-content> into
+    // its own container, so wrap the column in a single element that survives
+    // that move intact.
+    this.sourceView.classList.add("editor-source-view");
+
+    const helpBar = document.createElement("div");
+    helpBar.className = "editor-help-bar";
+    this.helpButton.setAttribute("label", "Help");
+    this.helpButton.setAttribute("flat", "");
+    this.helpButton.addEventListener("click", () => {
+      editorController.setHelpVisible(!editorController.helpVisible);
+    });
+    helpBar.appendChild(this.helpButton);
+
+    const contentColumn = document.createElement("div");
+    contentColumn.className = "editor-content";
+    contentColumn.append(this.sourceView, helpBar);
+
+    const content = new AdwBottomSheetContent();
+    content.appendChild(contentColumn);
+
+    // Slide-up sheet: the scrollable quick-help reference card.
+    const sheet = new AdwBottomSheetSheet();
+    const scroller = document.createElement("div");
+    scroller.className = "editor-help-scroller";
+    scroller.appendChild(this.quickHelp);
+    sheet.appendChild(scroller);
+
+    this.bottomSheet.append(content, sheet);
+    // A user dismissal (drag handle / dimming / Esc) flips `open` — mirror it
+    // back onto the shared controller so the help state stays single-sourced.
+    this.bottomSheet.addEventListener("notify::open", (event) => {
+      if (this.syncingHelp) return;
+      const open = (event as CustomEvent<{ open: boolean }>).detail.open;
+      this.syncingHelp = true;
+      editorController.setHelpVisible(open);
+      this.syncingHelp = false;
+    });
+
+    this.replaceChildren(this.bottomSheet);
+
+    this.initializeWithController();
+  }
+
+  private initializeWithController(): void {
+    if (this.initialized) return;
+    this.initialized = true;
+
+    editorController.init(this.sourceView);
+    editorController.events.on("changed", this.onControllerChanged);
+    editorController.events.on("helpVisibilityChanged", this.onHelpVisibilityChanged);
+
+    // Seed the sheet from the controller's persisted help state.
+    this.bottomSheet.open = editorController.helpVisible;
+  }
+}
+
+customElements.define("learn-editor", AdwEditorView);

--- a/packages/app-web/src/widgets/editor/index.ts
+++ b/packages/app-web/src/widgets/editor/index.ts
@@ -1,0 +1,6 @@
+import "@gjsify/adwaita-web/source-view"; // registers <adw-source-view> (CodeMirror upgrade), self-injects its stylesheet
+import "./styles.js";
+
+export * from "./editor-view.js";
+export * from "./source-view.js";
+export * from "./quick-help.js";

--- a/packages/app-web/src/widgets/editor/quick-help.ts
+++ b/packages/app-web/src/widgets/editor/quick-help.ts
@@ -1,0 +1,35 @@
+import { AdwClamp } from "@gjsify/adwaita-web";
+import quickHelpHtml from "@learn6502/learn/dist/quick-help.html";
+
+/**
+ * QuickHelp — the 6502 reference card shown in the Editor's help sheet.
+ *
+ * Web twin of app-gnome's `QuickHelpView extends MdxView` (`quick-help.ui`) and
+ * the help window's content: the generated `quick-help.html` fragment from
+ * `@learn6502/learn`'s HTML render target (built from the SAME `quick-help.mdx`
+ * as the GTK `.ui` XML and NativeScript XML). Unlike the tutorial, this fragment
+ * is pure reference prose (memory map, colour palette, registers,
+ * addressing/opcodes) with no `<adw-source-view>` code blocks, so there is
+ * nothing to upgrade or forward — the view only mounts the fragment in a clamp.
+ */
+export class QuickHelp extends HTMLElement {
+  private built = false;
+
+  connectedCallback(): void {
+    this.ensureBuilt();
+  }
+
+  private ensureBuilt(): void {
+    if (this.built) return;
+    this.built = true;
+
+    const clamp = new AdwClamp();
+    clamp.setAttribute("maximum-size", "600");
+    // Trusted build output (the learn package's own MDX render target), not
+    // user input.
+    clamp.innerHTML = quickHelpHtml;
+    this.replaceChildren(clamp);
+  }
+}
+
+customElements.define("learn-quick-help", QuickHelp);

--- a/packages/app-web/src/widgets/editor/source-view.ts
+++ b/packages/app-web/src/widgets/editor/source-view.ts
@@ -1,0 +1,148 @@
+import { EventDispatcher } from "@learn6502/core";
+import type { SourceViewEventMap, SourceViewWidget } from "@learn6502/common-ui";
+import type { AdwSourceView } from "@gjsify/adwaita-web/source-view";
+
+/**
+ * SourceView — the web `SourceViewWidget` implemented over the CodeMirror-backed
+ * `<adw-source-view>` custom element (`@gjsify/adwaita-web/source-view`).
+ *
+ * Web twin of app-gnome's `SourceView extends Adw.Bin` (a `GtkSource.View`) and
+ * app-android's NativeScript source view: a 6502-highlighted editor that maps
+ * onto the shared `SourceViewWidget` contract from `@learn6502/common-ui`
+ * (`code` / `lineNumbers` / `editable` / `readonly` / `lineNumberStart` /
+ * `selectable` / `copyable` / `copyButtonIcon` / `copyButtonTooltip`).
+ *
+ * The custom element already exposes that exact property surface (see
+ * `adwaita-web/src/source-view/adw-source-view.ts`); this wrapper's only real
+ * jobs are to (1) satisfy the `EventDispatcher`-based `SourceViewEventMap`
+ * contract the controllers expect and (2) bridge the DOM `code-changed` /
+ * `copy` CustomEvents the element emits to `events.dispatch("changed" | "copy")`
+ * — the same seam GNOME's `SourceView` uses (`buffer.connect("changed", …)` /
+ * copy-button click → `this.events.dispatch(…)`).
+ *
+ * @emits changed - when the user edits the buffer
+ * @emits copy    - when the copy button is pressed
+ */
+export class SourceView extends HTMLElement implements SourceViewWidget {
+  readonly events: EventDispatcher<SourceViewEventMap> = new EventDispatcher<SourceViewEventMap>();
+
+  private editor: AdwSourceView | null = null;
+  private built = false;
+
+  // Persisted property state, applied to the element once it is built. Mirrors
+  // the AdwSourceView field defaults so a value set before connect survives.
+  private pendingCode = "";
+  private pendingEditable = true;
+  private pendingLanguage = "6502";
+  private pendingLineNumbers = true;
+  private pendingSelectable = true;
+  private pendingCopyable = false;
+
+  private readonly onCodeChanged = (event: Event): void => {
+    const detail = (event as CustomEvent<{ code: string }>).detail;
+    this.events.dispatch("changed", { code: detail?.code ?? this.code });
+  };
+
+  private readonly onCopy = (event: Event): void => {
+    const detail = (event as CustomEvent<{ code: string }>).detail;
+    this.events.dispatch("copy", { code: detail?.code ?? this.code });
+  };
+
+  connectedCallback(): void {
+    this.ensureBuilt();
+  }
+
+  // --- SourceViewWidget interface ---
+
+  get code(): string {
+    return this.editor ? this.editor.code : this.pendingCode;
+  }
+
+  set code(value: string) {
+    this.pendingCode = value ?? "";
+    if (this.editor) this.editor.code = this.pendingCode;
+  }
+
+  get editable(): boolean {
+    return this.editor ? this.editor.editable : this.pendingEditable;
+  }
+
+  set editable(value: boolean) {
+    this.pendingEditable = !!value;
+    if (this.editor) this.editor.editable = this.pendingEditable;
+  }
+
+  get readonly(): boolean {
+    return !this.editable;
+  }
+
+  set readonly(value: boolean) {
+    this.editable = !value;
+  }
+
+  get lineNumbers(): boolean {
+    return this.editor ? this.editor.lineNumbers : this.pendingLineNumbers;
+  }
+
+  set lineNumbers(value: boolean) {
+    this.pendingLineNumbers = !!value;
+    if (this.editor) this.editor.lineNumbers = this.pendingLineNumbers;
+  }
+
+  get selectable(): boolean {
+    return this.editor ? this.editor.selectable : this.pendingSelectable;
+  }
+
+  set selectable(value: boolean) {
+    this.pendingSelectable = !!value;
+    if (this.editor) this.editor.selectable = this.pendingSelectable;
+  }
+
+  get copyable(): boolean {
+    return this.editor ? this.editor.copyable : this.pendingCopyable;
+  }
+
+  set copyable(value: boolean) {
+    this.pendingCopyable = !!value;
+    if (this.editor) this.editor.copyable = this.pendingCopyable;
+  }
+
+  /** The highlight language (`6502` enables the assembler mode). */
+  get language(): string {
+    return this.editor ? this.editor.language : this.pendingLanguage;
+  }
+
+  set language(value: string) {
+    this.pendingLanguage = value ?? "";
+    if (this.editor) this.editor.language = this.pendingLanguage;
+  }
+
+  /** Move keyboard focus into the CodeMirror editor. */
+  public focus(): boolean {
+    this.editor?.view?.focus();
+    return !!this.editor?.view?.hasFocus;
+  }
+
+  /** Build the `<adw-source-view>` once and wire its DOM events to the dispatcher. */
+  private ensureBuilt(): void {
+    if (this.built) return;
+    this.built = true;
+
+    const editor = document.createElement("adw-source-view") as AdwSourceView;
+    editor.language = this.pendingLanguage;
+    editor.editable = this.pendingEditable;
+    editor.lineNumbers = this.pendingLineNumbers;
+    editor.selectable = this.pendingSelectable;
+    editor.copyable = this.pendingCopyable;
+    editor.fillHeight = true;
+    editor.code = this.pendingCode;
+
+    editor.addEventListener("code-changed", this.onCodeChanged);
+    editor.addEventListener("copy", this.onCopy);
+
+    this.editor = editor;
+    this.replaceChildren(editor);
+  }
+}
+
+customElements.define("learn-source-view", SourceView);

--- a/packages/app-web/src/widgets/editor/styles.css
+++ b/packages/app-web/src/widgets/editor/styles.css
@@ -1,0 +1,53 @@
+/* Editor view — fill the pane so the CodeMirror editor gets the full height,
+   with the "Help" bar pinned below it (the web stand-in for editor.blp's
+   Adw.BottomSheet bottom-bar). */
+
+learn-editor {
+  display: block;
+  block-size: 100%;
+  min-block-size: 0;
+}
+
+learn-editor adw-bottom-sheet {
+  display: block;
+  block-size: 100%;
+}
+
+/* AdwBottomSheet's own content container (our .editor-content column lives
+   inside it) must stretch so the CodeMirror editor gets the full pane. */
+learn-editor .adw-bottom-sheet-content {
+  block-size: 100%;
+  min-block-size: 0;
+}
+
+.editor-content {
+  display: flex;
+  flex-direction: column;
+  block-size: 100%;
+  min-block-size: 0;
+}
+
+.editor-source-view {
+  display: block;
+  flex: 1 1 auto;
+  min-block-size: 0;
+  overflow: auto;
+}
+
+/* The source view fills its host; the CodeMirror surface scrolls internally. */
+.editor-source-view adw-source-view {
+  block-size: 100%;
+}
+
+.editor-help-bar {
+  display: flex;
+  justify-content: center;
+  padding: 12px;
+  border-block-start: 1px solid var(--border-color, rgba(0, 0, 0, 0.1));
+}
+
+.editor-help-scroller {
+  overflow-y: auto;
+  max-block-size: 60vh;
+  padding: 12px;
+}

--- a/packages/app-web/src/widgets/editor/styles.ts
+++ b/packages/app-web/src/widgets/editor/styles.ts
@@ -1,0 +1,15 @@
+/**
+ * Self-injects the Editor view's stylesheet (`./styles.css`) on import — the
+ * same pattern the Learn view (`widgets/learn/styles.ts`) and the debugger
+ * widgets use. The CSS is authored in a real `.css` file and imported as a
+ * string via gjsify's css-as-string.
+ */
+
+import editorCss from "./styles.css";
+
+if (typeof document !== "undefined" && !document.getElementById("learn-editor-style")) {
+  const style = document.createElement("style");
+  style.id = "learn-editor-style";
+  style.textContent = editorCss;
+  document.head.appendChild(style);
+}


### PR DESCRIPTION
Phase 3 of the app-web Adwaita rewrite: the Editor placeholder in the SPA shell becomes a real `AdwEditorView` — the web twin of app-gnome's `Editor` (`editor.blp`) and app-android's `Editor`, built on the CodeMirror-backed `<adw-source-view>` from `@gjsify/adwaita-web/source-view`.

## What's new

- **`SourceView`** (`widgets/editor/source-view.ts`) — the `SourceViewWidget` contract over `<adw-source-view>`: 6502 syntax highlighting + line-number gutter, bridging the element's DOM `code-changed`/`copy` events to the `EventDispatcher`-based `changed`/`copy` the controllers expect.
- **`AdwEditorView`** (`widgets/editor/editor-view.ts`) — the `EditorView` contract, delegating all logic to the shared `editorController`. Structure mirrors `editor.blp`: an `AdwBottomSheet` with the source editor as persistent content and a "Help" bar that reveals the quick-help sheet; the sheet's open state is two-way-bound to `editorController.helpVisible`.
- **`QuickHelp`** (`widgets/editor/quick-help.ts`) — renders the learn package's generated `quick-help.html` (memory map, colour palette, registers), the twin of app-gnome's `QuickHelpView`.
- **Shell wiring** — a user edit marks the program dirty (`editorController.changed` → `mainStateController.setCodeChanged(true)`, the `MainEventBridge` seam); the primary-menu "Help" item reveals the editor's quick-help sheet; the demo program is now the editor's starter buffer.

## Verification

Built with `gjsify build --app browser` (real 716 KB bundle + rewritten `index.html`) and driven in a headless browser:

- 3-column **desktop** (Learn | Editor | Console+Debugger) and **mobile** "Code" tab both render the editor with 6502 highlighting.
- Assemble is enabled from the seeded program (`hasCode`).
- The **Help** sheet slides up with the quick-help reference.
- **Typing** into CodeMirror is reflected and marks the program dirty.

`gjsify tsc --noEmit` clean; `gjsify format --check` clean.

Remaining rewrite phases: GameConsole view → tutorial TOC/per-section nav + Examples → delete-Jekyll + GH-Pages deploy.