### PR TITLE
Web: app-web GameConsole view (canvas display + d-pad)

### DIFF
--- a/packages/app-web/src/app/main-window.ts
+++ b/packages/app-web/src/app/main-window.ts
@@ -25,9 +25,10 @@
  * Phase 1 shipped the Debugger as the first REAL view (the ADR-0007 spike's
  * `AdwDebuggerView`, wired through the shared `GameConsoleEventBridge`).
  * Phase 2 added Learn (`AdwLearnView`, rendering `@learn6502/learn`'s generated
- * tutorial HTML). Phase 3 adds the Editor (`AdwEditorView`, the CodeMirror
- * `<adw-source-view>` + quick-help sheet). GameConsole remains an
- * `adw-status-page` placeholder that a later phase replaces.
+ * tutorial HTML). Phase 3 added the Editor (`AdwEditorView`, the CodeMirror
+ * `<adw-source-view>` + quick-help sheet). Phase 4 adds the GameConsole
+ * (`AdwGameConsoleView`, the `<canvas>` display + d-pad gamepad), upgrading the
+ * shared `gameConsoleController` from assembler-only to full display + input.
  */
 
 import {
@@ -35,7 +36,6 @@ import {
   AdwHeaderBar,
   AdwMenuButton,
   AdwOverlaySplitView,
-  AdwStatusPage,
   AdwToastOverlay,
   AdwToolbarView,
   AdwViewStack,
@@ -59,6 +59,7 @@ import { Assembler, Labels, Memory, Simulator, SimulatorState, formatMessage } f
 
 import { AdwDebuggerView } from "../views/adw-debugger.js";
 import { AdwEditorView } from "../widgets/editor/index.js";
+import { AdwGameConsoleView } from "../widgets/game-console/index.js";
 import { AdwLearnView } from "../widgets/learn/index.js";
 import { injectShellStyles } from "./styles.js";
 
@@ -102,9 +103,10 @@ export class MainWindow implements MainView {
   private readonly simulator = new Simulator(this.memory, this.labels);
   private readonly assembler = new Assembler(this.memory, this.labels);
 
-  // Real views; GameConsole remains a placeholder (later phase).
+  // Every view is now real (Learn, Editor, Debugger, GameConsole).
   private readonly debuggerView = new AdwDebuggerView();
   private readonly editorView = new AdwEditorView();
+  private readonly gameConsoleView = new AdwGameConsoleView();
   private readonly learnView = new AdwLearnView();
 
   // Persistent per-view slot wrappers, re-homed between the two layouts.
@@ -260,31 +262,18 @@ export class MainWindow implements MainView {
   }
 
   private buildViews(): void {
-    // GameConsole is still a placeholder; Learn, Editor and Debugger are real.
+    // All four views are real: Learn, Editor, Debugger and GameConsole.
     this.learnView.classList.add("shell-view-slot");
     this.learnSlot.appendChild(this.learnView);
 
     this.editorView.classList.add("shell-view-slot");
     this.editorSlot.appendChild(this.editorView);
 
-    this.gameConsoleSlot.appendChild(
-      this.placeholder(
-        "application-x-executable",
-        "Game Console",
-        "The display + gamepad view lands in a later phase. Assembled programs already run — watch the Debugger."
-      )
-    );
+    this.gameConsoleView.classList.add("shell-view-slot");
+    this.gameConsoleSlot.appendChild(this.gameConsoleView);
 
     this.debuggerView.classList.add("shell-view-slot");
     this.debuggerSlot.appendChild(this.debuggerView);
-  }
-
-  private placeholder(icon: string, title: string, description: string): AdwStatusPage {
-    const page = new AdwStatusPage();
-    page.setAttribute("icon", icon);
-    page.setAttribute("title", title);
-    page.setAttribute("description", description);
-    return page;
   }
 
   private buildChrome(): AdwWindow {
@@ -397,14 +386,11 @@ export class MainWindow implements MainView {
   // --- Controller wiring (the shared common-ui pipeline) ---
 
   private setupControllers(): void {
-    // GameConsole controller in assembler-only mode (no display/gamepad yet),
-    // exactly like the ADR-0007 spike.
-    gameConsoleController.initPartial({
-      memory: this.memory,
-      simulator: this.simulator,
-      assembler: this.assembler,
-      labels: this.labels,
-    });
+    // Full GameConsole: the real display + gamepad view over the shared
+    // gameConsoleController (upgrades the shell from the assembler-only
+    // initPartial). The view uses the shell's simulator stack (shared with the
+    // Debugger) rather than owning its own, so pass it in.
+    this.gameConsoleView.initialize(this.memory, this.simulator, this.assembler, this.labels);
 
     // The real Debugger view over the shared debuggerController.
     this.debuggerView.initialize(this.assembler, this.simulator);

--- a/packages/app-web/src/widgets/game-console/display.ts
+++ b/packages/app-web/src/widgets/game-console/display.ts
@@ -1,0 +1,111 @@
+import { DEFAULT_COLOR_PALETTE, DEFAULT_DISPLAY_CONFIG, type DisplayWidget } from "@learn6502/common-ui";
+import { DisplayAddressRange, type Memory, type MemoryChangedEvent } from "@learn6502/core";
+
+/**
+ * Display — the 6502 console screen as a `<canvas>`, implementing the shared
+ * `DisplayWidget` contract from `@learn6502/common-ui`.
+ *
+ * Web twin of app-gnome's `Display extends Adw.Bin` (a `Gtk.DrawingArea` +
+ * cairo) and app-android's Android canvas display. The 32×32 grid of the memory
+ * range `$0200-$05FF` (`DisplayAddressRange`) is painted with the shared 16-entry
+ * `DEFAULT_COLOR_PALETTE`; the pixel-plotting math is identical to the classic
+ * `app-web/src/display.ts` this replaces (`ctx.fillStyle = palette[val & 0x0f]`
+ * — no hex→RGB conversion needed for canvas, unlike cairo's 0-1 float API).
+ *
+ * The canvas keeps its native 320×320 buffer resolution while CSS scales it to
+ * fit the pane with `image-rendering: pixelated` for crisp square pixels.
+ */
+export class Display extends HTMLElement implements DisplayWidget {
+  private readonly width = DEFAULT_DISPLAY_CONFIG.width;
+  private readonly height = DEFAULT_DISPLAY_CONFIG.height;
+  private readonly numX = DEFAULT_DISPLAY_CONFIG.numX;
+  private readonly numY = DEFAULT_DISPLAY_CONFIG.numY;
+  private readonly pixelSize = this.width / this.numX;
+  private readonly palette = DEFAULT_COLOR_PALETTE;
+
+  private canvas: HTMLCanvasElement | null = null;
+  private ctx: CanvasRenderingContext2D | null = null;
+  private memory: Memory | null = null;
+  private built = false;
+  private subscribed = false;
+
+  private readonly onMemoryChanged = (event: MemoryChangedEvent): void => {
+    if (event.addr >= DisplayAddressRange.START && event.addr <= DisplayAddressRange.END) {
+      this.updatePixel(event.addr);
+    }
+  };
+
+  connectedCallback(): void {
+    this.ensureBuilt();
+  }
+
+  // --- DisplayWidget interface ---
+
+  /** Bind the display to memory: subscribe to changes, then paint the current state. */
+  public initialize(memory: Memory): void {
+    this.ensureBuilt();
+    this.memory = memory;
+    if (!this.subscribed) {
+      this.subscribed = true;
+      memory.on("changed", this.onMemoryChanged);
+    }
+    this.reset();
+    this.drawAllPixels();
+  }
+
+  /** Paint the whole screen black. */
+  public reset(): void {
+    if (!this.ctx) return;
+    this.ctx.fillStyle = "black";
+    this.ctx.fillRect(0, 0, this.width, this.height);
+  }
+
+  /** Repaint the single cell mapped to `addr`. */
+  public updatePixel(addr: number): void {
+    if (!this.ctx || !this.memory) return;
+    this.ctx.fillStyle = this.palette[this.memory.get(addr) & 0x0f];
+    const y = Math.floor((addr - DisplayAddressRange.START) / this.numY);
+    const x = (addr - DisplayAddressRange.START) % this.numX;
+    this.ctx.fillRect(x * this.pixelSize, y * this.pixelSize, this.pixelSize, this.pixelSize);
+  }
+
+  /** Repaint every cell from current memory. */
+  public drawAllPixels(): void {
+    for (let addr = DisplayAddressRange.START; addr <= DisplayAddressRange.END; addr++) {
+      this.updatePixel(addr);
+    }
+  }
+
+  /** Detach the memory subscription (the view's `close()`). */
+  public close(): void {
+    if (this.subscribed && this.memory) {
+      this.memory.off("changed", this.onMemoryChanged);
+      this.subscribed = false;
+    }
+  }
+
+  /** The focusable canvas element (the keyboard target — GNOME's `focusable` display). */
+  public get element(): HTMLCanvasElement | null {
+    return this.canvas;
+  }
+
+  private ensureBuilt(): void {
+    if (this.built) return;
+    this.built = true;
+
+    const canvas = document.createElement("canvas");
+    canvas.width = this.width;
+    canvas.height = this.height;
+    canvas.className = "game-console-screen";
+    // Focusable so it can receive keyboard input when the user plays (the GNOME
+    // twin's `focusable: true` DrawingArea).
+    canvas.tabIndex = 0;
+
+    this.canvas = canvas;
+    this.ctx = canvas.getContext("2d");
+    this.replaceChildren(canvas);
+    this.reset();
+  }
+}
+
+customElements.define("learn-display", Display);

--- a/packages/app-web/src/widgets/game-console/game-console-view.ts
+++ b/packages/app-web/src/widgets/game-console/game-console-view.ts
@@ -1,0 +1,160 @@
+import { AdwClamp } from "@gjsify/adwaita-web";
+import type { GameConsoleView, GamepadKey } from "@learn6502/common-ui";
+import { gameConsoleController, gameConsoleStateService } from "@learn6502/common-ui";
+import type { Assembler, Labels, Memory, Simulator } from "@learn6502/core";
+
+import { Display } from "./display.js";
+import { Gamepad } from "./gamepad.js";
+
+/**
+ * AdwGameConsoleView — the `GameConsoleView` from `@learn6502/common-ui`
+ * implemented over `@gjsify/adwaita-web`, the web twin of app-gnome's
+ * `GameConsole extends Adw.Bin` (`game-console.blp`) and app-android's
+ * `GameConsole`.
+ *
+ * Structure mirrors `game-console.blp`: a centred column with the `Display`
+ * canvas above the `Gamepad` d-pad. As on GNOME and Android, ALL logic lives in
+ * the shared `gameConsoleController`; this class only builds the widgets, calls
+ * the controller's full `init` (upgrading the shell from the assembler-only
+ * `initPartial`), and delegates the `GameConsoleView` actions.
+ *
+ * Unlike the GNOME twin the simulator stack is owned by the shell (`MainWindow`,
+ * shared with the Debugger), so `initialize()` receives it rather than creating
+ * its own via `createSimulatorStack()`.
+ */
+export class AdwGameConsoleView extends HTMLElement implements GameConsoleView {
+  private readonly displayWidget = new Display();
+  private readonly gamepadWidget = new Gamepad();
+
+  private _memory: Memory | null = null;
+  private _simulator: Simulator | null = null;
+  private _assembler: Assembler | null = null;
+  private _labels: Labels | null = null;
+
+  private built = false;
+  private initialized = false;
+
+  // A key press only drives the game while the display is focused, so playing
+  // never steals keystrokes from the Editor (the GNOME twin's focusable
+  // DrawingArea). WASD + arrows + Enter/Space are mapped by the input service.
+  private readonly onKeyDown = (event: KeyboardEvent): void => {
+    if (gameConsoleController.handleKeyPress(event.keyCode)) {
+      event.preventDefault();
+    }
+  };
+
+  connectedCallback(): void {
+    this.ensureBuilt();
+  }
+
+  // --- GameConsoleView interface (delegates to gameConsoleController) ---
+
+  public get simulator(): Simulator | null {
+    return this._simulator;
+  }
+
+  public get assembler(): Assembler | null {
+    return this._assembler;
+  }
+
+  public get memory(): Memory | null {
+    return this._memory;
+  }
+
+  public get labels(): Labels | null {
+    return this._labels;
+  }
+
+  public assemble(code: string): void {
+    gameConsoleController.assemble(code);
+  }
+
+  public run(): void {
+    gameConsoleController.run();
+  }
+
+  public hexdump(): void {
+    gameConsoleController.hexdump();
+  }
+
+  public disassemble(): void {
+    gameConsoleController.disassemble();
+  }
+
+  public stop(): void {
+    gameConsoleController.stop();
+  }
+
+  public reset(): void {
+    gameConsoleController.reset();
+  }
+
+  public step(): void {
+    gameConsoleController.step();
+  }
+
+  public goto(address: string): void {
+    gameConsoleController.goto(address);
+  }
+
+  public gamepadPress(key: GamepadKey): void {
+    this.gamepadWidget.press(key);
+  }
+
+  public close(): void {
+    this.displayWidget.element?.removeEventListener("keydown", this.onKeyDown);
+    this.displayWidget.close();
+    gameConsoleController.close();
+  }
+
+  /**
+   * Wire the view to the shell's simulator stack and switch the controller from
+   * assembler-only (`initPartial`) to full display + gamepad mode. Mirrors the
+   * GNOME `GameConsole.initialize()` shape.
+   */
+  public initialize(memory: Memory, simulator: Simulator, assembler: Assembler, labels: Labels): void {
+    this.ensureBuilt();
+
+    this._memory = memory;
+    this._simulator = simulator;
+    this._assembler = assembler;
+    this._labels = labels;
+
+    if (this.initialized) return;
+    this.initialized = true;
+
+    gameConsoleController.init({
+      memory,
+      displayWidget: this.displayWidget,
+      gamepadWidget: this.gamepadWidget,
+      simulator,
+      assembler,
+      labels,
+    });
+
+    // Keyboard input is scoped to the focused display (see onKeyDown).
+    this.displayWidget.element?.addEventListener("keydown", this.onKeyDown);
+
+    // Seed the screen with the colour-chart demo pattern so the console shows
+    // something before a program runs — the GNOME twin's initialize() does the
+    // same (`initializeMemoryWithTestPattern(memory, "colorChart")`).
+    gameConsoleStateService.initializeMemoryWithTestPattern(memory, "colorChart");
+    this.displayWidget.drawAllPixels();
+  }
+
+  private ensureBuilt(): void {
+    if (this.built) return;
+    this.built = true;
+
+    const column = document.createElement("div");
+    column.className = "game-console-column";
+    column.append(this.displayWidget, this.gamepadWidget);
+
+    const clamp = new AdwClamp();
+    clamp.setAttribute("maximum-size", "400");
+    clamp.appendChild(column);
+    this.replaceChildren(clamp);
+  }
+}
+
+customElements.define("learn-game-console", AdwGameConsoleView);

--- a/packages/app-web/src/widgets/game-console/gamepad.ts
+++ b/packages/app-web/src/widgets/game-console/gamepad.ts
@@ -1,0 +1,68 @@
+import { AdwButton } from "@gjsify/adwaita-web";
+import { type GamepadEventMap, type GamepadKey, type GamepadWidget, getGamepadKeyCode } from "@learn6502/common-ui";
+import { EventDispatcher } from "@learn6502/core";
+
+/** Direction/action buttons in DOM order, with the glyph shown on each. */
+const BUTTONS: ReadonlyArray<{ key: GamepadKey; glyph: string; area: string }> = [
+  { key: "Up", glyph: "▲", area: "up" },
+  { key: "Left", glyph: "◀", area: "left" },
+  { key: "Right", glyph: "▶", area: "right" },
+  { key: "Down", glyph: "▼", area: "down" },
+  { key: "B", glyph: "B", area: "b" },
+  { key: "A", glyph: "A", area: "a" },
+];
+
+/**
+ * Gamepad — the on-screen d-pad + A/B controller, implementing the shared
+ * `GamepadWidget` contract from `@learn6502/common-ui`.
+ *
+ * Web twin of app-gnome's `Gamepad extends Adw.Bin` (`gamepad.blp`, six
+ * `Gtk.Button`s) and app-android's Android gamepad. Each button click calls
+ * `press(key)`, which dispatches `keyPressed` with the ASCII key code
+ * (`getGamepadKeyCode`) — the `gameConsoleController` writes that byte to memory
+ * `$ff`, exactly like the GNOME/Android twins. A CSS grid lays the four
+ * direction buttons out as a d-pad with A/B to the right.
+ *
+ * @emits keyPressed - when any button is pressed
+ */
+export class Gamepad extends HTMLElement implements GamepadWidget {
+  readonly events: EventDispatcher<GamepadEventMap> = new EventDispatcher<GamepadEventMap>();
+
+  private built = false;
+
+  connectedCallback(): void {
+    this.ensureBuilt();
+  }
+
+  // --- GamepadWidget interface ---
+
+  public press(buttonName: GamepadKey): void {
+    this.events.dispatch("keyPressed", {
+      key: buttonName,
+      keyCode: getGamepadKeyCode(buttonName),
+    });
+  }
+
+  private ensureBuilt(): void {
+    if (this.built) return;
+    this.built = true;
+
+    const pad = document.createElement("div");
+    pad.className = "game-console-gamepad";
+
+    for (const { key, glyph, area } of BUTTONS) {
+      const button = new AdwButton();
+      button.setAttribute("label", glyph);
+      button.setAttribute("circular", "");
+      button.classList.add("gamepad-button", `gamepad-button--${area}`);
+      button.style.gridArea = area;
+      button.setAttribute("aria-label", key);
+      button.addEventListener("click", () => this.press(key));
+      pad.appendChild(button);
+    }
+
+    this.replaceChildren(pad);
+  }
+}
+
+customElements.define("learn-gamepad", Gamepad);

--- a/packages/app-web/src/widgets/game-console/index.ts
+++ b/packages/app-web/src/widgets/game-console/index.ts
@@ -1,0 +1,5 @@
+import "./styles.js";
+
+export * from "./game-console-view.js";
+export * from "./display.js";
+export * from "./gamepad.js";

--- a/packages/app-web/src/widgets/game-console/styles.css
+++ b/packages/app-web/src/widgets/game-console/styles.css
@@ -1,0 +1,57 @@
+/* GameConsole view — a centred column with the display canvas above the d-pad,
+   mirroring app-gnome's game-console.blp (Box → Display + Gamepad). */
+
+learn-game-console {
+  display: block;
+}
+
+.game-console-column {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+  padding: 24px 12px;
+}
+
+/* The canvas keeps its native 320×320 buffer; CSS scales it to fit the pane
+   with crisp square pixels (no smoothing). */
+.game-console-screen {
+  inline-size: 100%;
+  max-inline-size: 320px;
+  block-size: auto;
+  aspect-ratio: 1 / 1;
+  image-rendering: pixelated;
+  border-radius: 6px;
+  background: #000;
+  outline: none;
+}
+
+.game-console-screen:focus-visible {
+  box-shadow: 0 0 0 2px var(--accent-bg-color, #3584e4);
+}
+
+/* D-pad cross on the left, A/B on the right (game-console.blp gamepad layout). */
+.game-console-gamepad {
+  display: grid;
+  grid-template-columns: 44px 44px 44px 16px 48px 48px;
+  grid-template-rows: 44px 44px 44px;
+  gap: 6px;
+  align-items: center;
+  justify-items: center;
+  grid-template-areas:
+    ".    up   .     . .  b"
+    "left .    right . a  ."
+    ".    down .     . .  .";
+}
+
+.game-console-gamepad .gamepad-button {
+  min-inline-size: 44px;
+  min-block-size: 44px;
+}
+
+.game-console-gamepad .gamepad-button--a,
+.game-console-gamepad .gamepad-button--b {
+  min-inline-size: 48px;
+  min-block-size: 48px;
+  font-weight: bold;
+}

--- a/packages/app-web/src/widgets/game-console/styles.ts
+++ b/packages/app-web/src/widgets/game-console/styles.ts
@@ -1,0 +1,15 @@
+/**
+ * Self-injects the GameConsole view's stylesheet (`./styles.css`) on import —
+ * the same pattern the Learn/Editor views and the debugger widgets use. The CSS
+ * is authored in a real `.css` file and imported as a string via gjsify's
+ * css-as-string.
+ */
+
+import gameConsoleCss from "./styles.css";
+
+if (typeof document !== "undefined" && !document.getElementById("learn-game-console-style")) {
+  const style = document.createElement("style");
+  style.id = "learn-game-console-style";
+  style.textContent = gameConsoleCss;
+  document.head.appendChild(style);
+}


### PR DESCRIPTION
Phase 4 of the app-web Adwaita rewrite — the GameConsole placeholder becomes a real `AdwGameConsoleView`, the web twin of app-gnome's `GameConsole` (`game-console.blp`) and app-android's `GameConsole`. **This is the last of the four views to go real** (Learn, Editor, Debugger, GameConsole).

## What's new

- **`Display`** (`widgets/game-console/display.ts`) — the `DisplayWidget` contract as a `<canvas>`: the 32×32 grid of memory `$0200-$05FF` painted with the shared 16-entry `DEFAULT_COLOR_PALETTE`. Same pixel math as the classic `app-web/src/display.ts` it replaces (canvas takes the hex palette directly — no hex→RGB conversion, unlike cairo). Native 320×320 buffer, CSS-scaled with `image-rendering: pixelated`; focusable for keyboard play.
- **`Gamepad`** (`widgets/game-console/gamepad.ts`) — the `GamepadWidget` contract as a CSS-grid d-pad + A/B buttons over `AdwButton`. Each press dispatches `keyPressed` with `getGamepadKeyCode(key)`, which the controller writes to memory `$ff` — the same seam as the GNOME/Android twins.
- **`AdwGameConsoleView`** (`widgets/game-console/game-console-view.ts`) — the `GameConsoleView` contract, composing display + gamepad and delegating to the shared `gameConsoleController`. Its `initialize()` upgrades the shell from the assembler-only `initPartial` to the full `init` (display + gamepad + `$ff` input), seeds the colour-chart demo pattern, and scopes keyboard input (WASD/arrows/Enter/Space) to the **focused** display so playing never steals keystrokes from the Editor.
- **Shell** — `buildViews()` mounts the view; `setupControllers()` calls its `initialize(...)` with the shell's shared simulator stack (owned by `MainWindow`, shared with the Debugger) instead of `initPartial`. The now-unused `placeholder()` helper + `AdwStatusPage` import are dropped.

## Verification

Built with `gjsify build --app browser` and driven in a headless browser (screenshots captured):

- The display paints the **colour-chart** palette bands on load (89,600 non-black px).
- **Assemble + Run** fills the screen with the demo program's random colours — live per-pixel updates (`STA $0200,X` loop) — and fires the *Assembled successfully* / *Program completed* toasts.
- The **d-pad + A/B** render and click without error.
- The mobile **"Play"** tab shows the console full-width.

`gjsify tsc --noEmit` clean; `gjsify format --check` clean.

Remaining rewrite phases: tutorial TOC / per-section nav + Examples list, then delete-Jekyll + GH-Pages deploy (the hard cutover).