### PR TITLE
Web: drop stale "(Phase 1)" from app-web title

### DIFF
--- a/packages/app-web/app.html
+++ b/packages/app-web/app.html
@@ -4,12 +4,11 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="color-scheme" content="light dark" />
-    <title>Learn 6502 Assembly — Adwaita SPA (Phase 1)</title>
+    <title>Learn 6502 Assembly</title>
   </head>
   <body>
-    <!-- Dev entry for the new adwaita-web shell (Vite gjsifyBrowser preset).
-         Separate from the classic Jekyll site so its published output is
-         untouched. Production is built with `gjsify build --app browser`. -->
+    <!-- Dev entry for the adwaita-web shell (Vite gjsifyBrowser preset).
+         Production is built with `gjsify build --app browser`. -->
     <script type="module" src="./src/app/main.ts"></script>
   </body>
 </html>


### PR DESCRIPTION
The browser tab / page title still read *"Learn 6502 Assembly — Adwaita SPA (Phase 1)"*, a leftover from the phased rewrite (now complete and live at https://jumplink.eu/Learn6502/). Trim it to **"Learn 6502 Assembly"** and drop the now-obsolete `app.html` comment about the classic Jekyll site (removed in the cutover).

Verified: `build:app` emits `<title>Learn 6502 Assembly</title>`. Merging retriggers the Pages deploy (app.html is in the deploy workflow's trigger paths).